### PR TITLE
Fixed method name for replay detection

### DIFF
--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -46,7 +46,7 @@ You can also detect the start and end of event replay by listening for the `Spat
 Though, under normal circumstances, you don't need to know this, you can detect if events are currently being replayed like this:
 
 ```php
-Spatie\EventSourcing\Facades\Projectionist::isReplayingEvents(); // returns a boolean
+Spatie\EventSourcing\Facades\Projectionist::isReplaying(); // returns a boolean
 ```
 
 ## Performing some work before and after replaying events


### PR DESCRIPTION
The correct method name for detecting replay should be `Spatie\EventProjector\Facades\Projectionist::isReplaying();`.