### PR TITLE
StoredEventRepository should not be opinionated

### DIFF
--- a/src/EloquentStoredEventRepository.php
+++ b/src/EloquentStoredEventRepository.php
@@ -35,7 +35,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         });
     }
 
-    public function retrieveAllStartingFrom(int $startingFrom, string $uuid = null): LazyCollection
+    public function retrieveAllStartingFrom($startingFrom, string $uuid = null): LazyCollection
     {
         /** @var \Illuminate\Database\Query\Builder $query */
         $query = $this->storedEventModel::query()->startingFrom($startingFrom);

--- a/src/StoredEventRepository.php
+++ b/src/StoredEventRepository.php
@@ -8,7 +8,7 @@ interface StoredEventRepository
 {
     public function retrieveAll(string $uuid = null): LazyCollection;
 
-    public function retrieveAllStartingFrom(int $startingFrom, string $uuid = null): LazyCollection;
+    public function retrieveAllStartingFrom($startingFrom, string $uuid = null): LazyCollection;
 
     public function persist(ShouldBeStored $event, string $uuid = null): StoredEvent;
 


### PR DESCRIPTION
The StoredEventRepository interface should not impose an int $startingFrom type as another repository implementation may use a different lookup method.

An example would be for a repository which does not use an auto-incrementing primary key and, instead of returning the events ordered by ID, returns the events ordered by milliseconds, microseconds or nanoseconds. In this implementation retrieveAllStartingFrom may expect a float, string, or some other variable type to appropriately handle the offset and replay the events.