### PR TITLE
Implemented missing HandleDomainEventJob interface

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -58,7 +58,7 @@ return [
     /*
      * This class is responsible for handling stored events. To add extra behaviour you
      * can change this to a class of your own. The only restriction is that
-     * it should extend \Spatie\EventSourcing\HandleDomainEventJob.
+     * it should implement \Spatie\EventSourcing\HandleDomainEventJob.
      */
     'stored_event_job' => \Spatie\EventSourcing\HandleStoredEventJob::class,
 

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -76,7 +76,7 @@ return [
     /*
      * This class is responsible for handle stored events. To add extra behaviour you
      * can change this to a class of your own. The only restriction is that
-     * it should extend \Spatie\EventSourcing\HandleDomainEventJob.
+     * it should implement \Spatie\EventSourcing\HandleDomainEventJob.
      */
     'stored_event_job' => \Spatie\EventSourcing\HandleStoredEventJob::class,
 

--- a/src/HandleDomainEventJob.php
+++ b/src/HandleDomainEventJob.php
@@ -2,8 +2,6 @@
 
 namespace Spatie\EventSourcing;
 
-use Illuminate\Contracts\Queue\ShouldQueue;
-
 interface HandleDomainEventJob
 {
     public function handle(Projectionist $projectionist): void;

--- a/src/HandleDomainEventJob.php
+++ b/src/HandleDomainEventJob.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\EventSourcing;
+
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+interface HandleDomainEventJob
+{
+    public function handle(Projectionist $projectionist): void;
+
+    public function tags(): array;
+
+    public static function createForEvent(StoredEvent $event, array $tags): self;
+}

--- a/src/HandleStoredEventJob.php
+++ b/src/HandleStoredEventJob.php
@@ -7,7 +7,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Contracts\Queue\ShouldQueue;
 
-final class HandleStoredEventJob implements ShouldQueue
+final class HandleStoredEventJob implements HandleDomainEventJob, ShouldQueue
 {
     use InteractsWithQueue, Queueable, SerializesModels;
 
@@ -36,7 +36,7 @@ final class HandleStoredEventJob implements ShouldQueue
             : $this->tags;
     }
 
-    public static function createForEvent(StoredEvent $event, array $tags): self
+    public static function createForEvent(StoredEvent $event, array $tags): HandleDomainEventJob
     {
         return new static($event, $tags);
     }


### PR DESCRIPTION
Both the config and documentation reference a missing Spatie\EventSourcing\HandleDomainEventJob class. At first I assumed this was a typo for the HandleStoredEventJob class, however, the class is final and can't be extended.

Instead, as hopefully makes more sense, I implement a HandleDomainEventJob interface in a non-breaking way that follows the rest of the codebase. I additionally updated the documentation to reference implementing rather than extending the new HandleDomainEventJob interface.