### PR TITLE
Use a UUID field when possible for storing UUIDs

### DIFF
--- a/stubs/create_stored_events_table.php.stub
+++ b/stubs/create_stored_events_table.php.stub
@@ -10,7 +10,7 @@ final class CreateStoredEventsTable extends Migration
     {
         Schema::create('stored_events', function (Blueprint $table) {
             $table->increments('id');
-            $table->string('aggregate_uuid')->nullable();
+            $table->uuid('aggregate_uuid')->nullable();
             $table->string('event_class');
             $table->json('event_properties');
             $table->json('meta_data');

--- a/tests/TestClasses/FakeUuid.php
+++ b/tests/TestClasses/FakeUuid.php
@@ -8,7 +8,7 @@ final class FakeUuid
 
     public static function generate()
     {
-        return '594713b3-0000-4000-b300-'.sprintf("%012d", self::$count++);
+        return '594713b3-0000-4000-b300-'.sprintf('%012d', self::$count++);
     }
 
     public static function reset()

--- a/tests/TestClasses/FakeUuid.php
+++ b/tests/TestClasses/FakeUuid.php
@@ -8,7 +8,7 @@ final class FakeUuid
 
     public static function generate()
     {
-        return 'uuid-'.self::$count++;
+        return '594713b3-0000-4000-b300-'.sprintf("%012d", self::$count++);
     }
 
     public static function reset()


### PR DESCRIPTION
Using a UUID field, rather than a varchar, to store the UUIDs in Postgres has a storage and performance benefit (the UUID field only occupies [16 bytes](https://github.com/postgres/postgres/blob/master/src/include/utils/uuid.h#L18) as opposed to the 37 bytes the varchar is currently occupying).

Since the [MySQL grammar](https://github.com/illuminate/database/blob/master/Schema/Grammars/MySqlGrammar.php#L735) handles the lack of a native UUID type there is no negative impact on MySQL for this change.

This simply changes the stub and has no impact on existing codebases. I additionally updated the FakeUUID class to generate a valid V4 UUID so all the tests still pass on both MySQL and Postgres.