### PR TITLE
Use "self" typehints in AggregateRoot

### DIFF
--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -13,7 +13,7 @@ abstract class AggregateRoot
     /** @var array */
     private $recordedEvents = [];
 
-    public static function retrieve(string $uuid): AggregateRoot
+    public static function retrieve(string $uuid): self
     {
         $aggregateRoot = (new static());
 
@@ -22,7 +22,7 @@ abstract class AggregateRoot
         return $aggregateRoot->reconstituteFromEvents();
     }
 
-    public function recordThat(ShouldBeStored $domainEvent): AggregateRoot
+    public function recordThat(ShouldBeStored $domainEvent): self
     {
         $this->recordedEvents[] = $domainEvent;
 
@@ -31,7 +31,7 @@ abstract class AggregateRoot
         return $this;
     }
 
-    public function persist(): AggregateRoot
+    public function persist(): self
     {
         $storedEvents = call_user_func(
             [$this->getStoredEventRepository(), 'persistMany'],
@@ -65,7 +65,7 @@ abstract class AggregateRoot
         return $recordedEvents;
     }
 
-    private function reconstituteFromEvents(): AggregateRoot
+    private function reconstituteFromEvents(): self
     {
         $this->getStoredEventRepository()->retrieveAll($this->aggregateUuid)
             ->each(function (StoredEvent $storedEvent) {


### PR DESCRIPTION
While IDEs like PHPStorm can infer custom method calls due to usage of
"$this", actual code completion seems to only be working when the
correct method name is being called, as no auto-completion hints
appear when referencing the base "AggregateRoot" type.

I wasn't sure what to include in the changelog since subclasses could  change the return type and may have to be updated. Would this be a .1 or a .0.1 release then?