### PR TITLE
Fix replay from specified event id

### DIFF
--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -263,7 +263,7 @@ final class Projectionist
 
         $projectors->call('onStartingEventReplay');
 
-        app(StoredEventRepository::class)->retrieveAll(null, $startingFromEventId ?? 0)->each(function (StoredEvent $storedEvent) use ($projectors, $onEventReplayed) {
+        app(StoredEventRepository::class)->retrieveAllStartingFrom($startingFromEventId)->each(function (StoredEvent $storedEvent) use ($projectors, $onEventReplayed) {
             $this->applyStoredEventToProjectors(
                 $storedEvent,
                 $projectors->forEvent($storedEvent)


### PR DESCRIPTION
Today I tried to replay a projection not from beginning of the event stream, but from a certain event id. This worked in the "old" event projector packages, but to my surprise it showed the following:

<img width="489" alt="console" src="https://user-images.githubusercontent.com/4008663/69227236-d0345a00-0b81-11ea-8c9c-25931d4598a3.png">

A quick look in the code revealed, that the wrong method was called... Here's the fix.

* Call correct method
* Organize params, as the first one now should be the starting id
* Remove coalesce operator (param has to be int and never is null)