### PR TITLE
Snapshotting AggregateRoot

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -56,6 +56,13 @@ return [
     'stored_event_repository' => \Spatie\EventSourcing\EloquentStoredEventRepository::class,
 
     /*
+     * This class is responsible for storing events. To add extra behaviour you
+     * can change this to a class of your own. The only restriction is that
+     * it should implement \Spatie\EventSourcing\StoredEventRepository.
+     */
+    'snapshot_repository' => \Spatie\EventSourcing\EloquentSnapshotRepository::class,
+
+    /*
      * This class is responsible for handling stored events. To add extra behaviour you
      * can change this to a class of your own. The only restriction is that
      * it should implement \Spatie\EventSourcing\HandleDomainEventJob.

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -141,7 +141,7 @@ abstract class AggregateRoot
             $this->$applyingMethodName($event);
         }
 
-        ++$this->aggregateVersion;
+        $this->aggregateVersion++;
     }
 
     /**

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -6,7 +6,6 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Str;
 use ReflectionClass;
 use ReflectionProperty;
-use Spatie\SchemalessAttributes\SchemalessAttributes;
 
 abstract class AggregateRoot
 {

--- a/src/EloquentSnapshotRepository.php
+++ b/src/EloquentSnapshotRepository.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Spatie\EventSourcing;
+
+use Spatie\EventSourcing\Exceptions\InvalidEloquentSnapshotModel;
+use Spatie\EventSourcing\Models\EloquentSnapshot;
+
+class EloquentSnapshotRepository implements SnapshotRepository
+{
+    protected $snapshotModel;
+
+    public function __construct()
+    {
+        $this->snapshotModel = config('event-sourcing.snapshot_model', EloquentSnapshot::class);
+
+        if (! new $this->snapshotModel instanceof EloquentSnapshot) {
+            throw new InvalidEloquentSnapshotModel("The class {$this->snapshotModel} must extend EloquentSnapshot");
+        }
+    }
+
+    public function retrieve(string $aggregateUuid): ?Snapshot
+    {
+        /** @var \Illuminate\Database\Query\Builder $query */
+        $query = $this->snapshotModel::query();
+
+        if ($snapshot = $query->latest()->uuid($aggregateUuid)->first()) {
+            return $snapshot->toSnapshot();
+        }
+
+        return null;
+    }
+
+    public function persist(Snapshot $snapshot): Snapshot
+    {
+        /** @var EloquentSnapshot $eloquentSnapshot */
+        $eloquentSnapshot = new $this->snapshotModel();
+
+        $eloquentSnapshot->aggregate_uuid = $snapshot->aggregateUuid;
+        $eloquentSnapshot->aggregate_version = $snapshot->aggregateVersion;
+        $eloquentSnapshot->state = $snapshot->state;
+
+        $eloquentSnapshot->save();
+
+        return $eloquentSnapshot->toSnapshot();
+    }
+}

--- a/src/Exceptions/InvalidEloquentSnapshotModel.php
+++ b/src/Exceptions/InvalidEloquentSnapshotModel.php
@@ -4,6 +4,6 @@ namespace Spatie\EventSourcing\Exceptions;
 
 use Exception;
 
-final class InvalidEloquentSnapshotModel extends Exception
+class InvalidEloquentSnapshotModel extends Exception
 {
 }

--- a/src/Exceptions/InvalidEloquentSnapshotModel.php
+++ b/src/Exceptions/InvalidEloquentSnapshotModel.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\EventSourcing\Exceptions;
+
+use Exception;
+
+final class InvalidEloquentSnapshotModel extends Exception
+{
+}

--- a/src/Models/EloquentSnapshot.php
+++ b/src/Models/EloquentSnapshot.php
@@ -5,7 +5,6 @@ namespace Spatie\EventSourcing\Models;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Spatie\EventSourcing\Snapshot;
-use Spatie\SchemalessAttributes\SchemalessAttributes;
 
 class EloquentSnapshot extends Model
 {

--- a/src/Models/EloquentSnapshot.php
+++ b/src/Models/EloquentSnapshot.php
@@ -4,9 +4,7 @@ namespace Spatie\EventSourcing\Models;
 
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
-use Spatie\EventSourcing\ShouldBeStored;
 use Spatie\EventSourcing\Snapshot;
-use Spatie\EventSourcing\StoredEvent;
 use Spatie\SchemalessAttributes\SchemalessAttributes;
 
 class EloquentSnapshot extends Model

--- a/src/Models/EloquentSnapshot.php
+++ b/src/Models/EloquentSnapshot.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Spatie\EventSourcing\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Spatie\EventSourcing\ShouldBeStored;
+use Spatie\EventSourcing\Snapshot;
+use Spatie\EventSourcing\StoredEvent;
+use Spatie\SchemalessAttributes\SchemalessAttributes;
+
+class EloquentSnapshot extends Model
+{
+    public $guarded = [];
+
+    public $timestamps = false;
+
+    protected $table = 'snapshots';
+
+    public $casts = [
+        'state' => 'array',
+    ];
+
+    public function toSnapshot(): Snapshot
+    {
+        return new Snapshot($this->aggregate_uuid, $this->aggregate_version, $this->state);
+    }
+
+    public function getStateAttribute(): SchemalessAttributes
+    {
+        return SchemalessAttributes::createForModel($this, 'state');
+    }
+
+    public function scopeUuid(Builder $query, string $uuid): void
+    {
+        $query->where('aggregate_uuid', $uuid);
+    }
+}

--- a/src/Models/EloquentSnapshot.php
+++ b/src/Models/EloquentSnapshot.php
@@ -24,11 +24,6 @@ class EloquentSnapshot extends Model
         return new Snapshot($this->aggregate_uuid, $this->aggregate_version, $this->state);
     }
 
-    public function getStateAttribute(): SchemalessAttributes
-    {
-        return SchemalessAttributes::createForModel($this, 'state');
-    }
-
     public function scopeUuid(Builder $query, string $uuid): void
     {
         $query->where('aggregate_uuid', $uuid);

--- a/src/Models/EloquentStoredEvent.php
+++ b/src/Models/EloquentStoredEvent.php
@@ -53,6 +53,11 @@ class EloquentStoredEvent extends Model
         $query->where('id', '>=', $storedEventId);
     }
 
+    public function scopeAfterVersion(Builder $query, int $version): void
+    {
+        $query->where('aggregate_version', '>', $version);
+    }
+
     public function scopeUuid(Builder $query, string $uuid): void
     {
         $query->where('aggregate_uuid', $uuid);

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\EventSourcing;
+
+class Snapshot
+{
+    public string $aggregateUuid;
+
+    public int $aggregateVersion;
+
+    /** @var mixed */
+    public $state;
+
+    public function __construct(
+        string $aggregateUuid,
+        int $aggregateVersion,
+        $state
+    ) {
+        $this->aggregateUuid = $aggregateUuid;
+        $this->aggregateVersion = $aggregateVersion;
+        $this->state = $state;
+    }
+}

--- a/src/Snapshot.php
+++ b/src/Snapshot.php
@@ -8,8 +8,7 @@ class Snapshot
 
     public int $aggregateVersion;
 
-    /** @var mixed */
-    public $state;
+    public array $state;
 
     public function __construct(
         string $aggregateUuid,

--- a/src/SnapshotRepository.php
+++ b/src/SnapshotRepository.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\EventSourcing;
+
+interface SnapshotRepository
+{
+    public function retrieve(string $aggregateUuid): ?Snapshot;
+
+    public function persist(Snapshot $snapshot): Snapshot;
+}

--- a/src/StoredEvent.php
+++ b/src/StoredEvent.php
@@ -5,7 +5,6 @@ namespace Spatie\EventSourcing;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Collection;
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\Exceptions\InvalidStoredEvent;
 use Spatie\EventSourcing\Facades\Projectionist;

--- a/src/StoredEventRepository.php
+++ b/src/StoredEventRepository.php
@@ -10,9 +10,11 @@ interface StoredEventRepository
 
     public function retrieveAllStartingFrom(int $startingFrom, string $uuid = null): LazyCollection;
 
-    public function persist(ShouldBeStored $event, string $uuid = null): StoredEvent;
+    public function retrieveAllAfterVersion(int $aggregateVersion, string $aggregateUuid): LazyCollection;
 
-    public function persistMany(array $events, string $uuid = null): LazyCollection;
+    public function persist(ShouldBeStored $event, string $uuid = null, int $aggregateVersion = null): StoredEvent;
+
+    public function persistMany(array $events, string $uuid = null, int $aggregateVersion = null): LazyCollection;
 
     public function update(StoredEvent $storedEvent): StoredEvent;
 }

--- a/stubs/create_snapshots_table.php.stub
+++ b/stubs/create_snapshots_table.php.stub
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-final class CreateSnapshotsTable extends Migration
+class CreateSnapshotsTable extends Migration
 {
     public function up()
     {

--- a/stubs/create_snapshots_table.php.stub
+++ b/stubs/create_snapshots_table.php.stub
@@ -1,0 +1,20 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+final class CreateSnapshotsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('snapshots', function (Blueprint $table) {
+            $table->increments('id');
+            $table->uuid('aggregate_uuid');
+            $table->unsignedInteger('aggregate_version');
+            $table->json('state');
+            $table->timestamp('created_at');
+            $table->index('aggregate_uuid');
+        });
+    }
+}

--- a/stubs/create_stored_events_table.php.stub
+++ b/stubs/create_stored_events_table.php.stub
@@ -11,6 +11,7 @@ final class CreateStoredEventsTable extends Migration
         Schema::create('stored_events', function (Blueprint $table) {
             $table->increments('id');
             $table->uuid('aggregate_uuid')->nullable();
+            $table->unsignedInteger('aggregate_version')->nullable();
             $table->string('event_class');
             $table->json('event_properties');
             $table->json('meta_data');

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -152,7 +152,7 @@ final class AggregateRootTest extends TestCase
 
         $this->assertEquals(1, EloquentSnapshot::count());
         tap(EloquentSnapshot::first(), function (EloquentSnapshot $snapshot) {
-            $this->assertEquals(300, $snapshot->state->balance);
+            $this->assertEquals(300, $snapshot->state['balance']);
             $this->assertEquals(3, $snapshot->aggregate_version);
         });
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,6 +48,10 @@ abstract class TestCase extends Orchestra
         include_once __DIR__.'/../stubs/create_stored_events_table.php.stub';
         (new \CreateStoredEventsTable())->up();
 
+        Schema::dropIfExists('snapshots');
+        include_once __DIR__.'/../stubs/create_snapshots_table.php.stub';
+        (new \CreateSnapshotsTable())->up();
+
         Schema::dropIfExists('other_stored_events');
         if ($this->dbDriver() === 'mysql') {
             DB::statement('CREATE TABLE other_stored_events LIKE stored_events');

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRoot.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRoot.php
@@ -10,6 +10,8 @@ final class AccountAggregateRoot extends AggregateRoot
 {
     public int $balance = 0;
 
+    public int $aggregateVersion = 0;
+
     public function addMoney(int $amount): self
     {
         $this->recordThat(new MoneyAdded($amount));


### PR DESCRIPTION
This implements snapshotting of AggregateRoots
- Adds a `snapshot()` method to the AggregateRoot which creates a new Snapshot
- AggregateRoots track a `version` number, which increments each time an event is applied
- Persisting the events persists them with the version number
- The AggregateRoot has a `getState` and `useState` function to determine the state that is saved and retrieved from the snapshot, by default all properties on the class are stored in the snapshot

- When initializing an AggregateRoot, we check if there is a snapshot, if there is we load the state first, then retrieve and reconstitute from all events that happened after the snapshot.
- All public properties on an aggregate are stored as the state of the snapshot, in the tests this is the `$balance` property of the `AccountAggregate`, when restoring a snapshot, we set them back.

- We should also credit https://github.com/EventSaucePHP/EventSauce as the implementation is based on how EventSauce does it.

This will require a new major version, as some interfaces and a migration have changed, steps to upgrade:
- Add an `aggregate_version` property to the `stored_events` table `$table->unsignedInteger('aggregate_version')->nullable();`
- Republish the migrations or copy the `create_snapshots_table` migration
- The `StoredEventRepository` interface has a new method `retrieveAllAfterVersion` that you must implement if you have a custom repository
- The `StoredEventRepository` now accepts an `aggregateVersion` parameter in the `persist` and `persistMany` methods