### PR TITLE
fix slow replay

### DIFF
--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -65,8 +65,7 @@ class ReplayCommand extends Command
     public function replay(Collection $projectors, int $startingFrom): void
     {
         $repository = app(StoredEventRepository::class);
-        $events = $repository->retrieveAllStartingFrom($startingFrom);
-        $replayCount = $events->count();
+        $replayCount = $repository->countAllStartingFrom($startingFrom);
 
         if ($replayCount === 0) {
             $this->warn('There are no events to replay');
@@ -76,7 +75,7 @@ class ReplayCommand extends Command
 
         $this->comment("Replaying {$replayCount} events...");
 
-        $bar = $this->output->createProgressBar($events->count());
+        $bar = $this->output->createProgressBar($replayCount);
         $onEventReplayed = function () use ($bar) {
             $bar->advance();
         };

--- a/src/StoredEventRepository.php
+++ b/src/StoredEventRepository.php
@@ -10,6 +10,8 @@ interface StoredEventRepository
 
     public function retrieveAllStartingFrom(int $startingFrom, string $uuid = null): LazyCollection;
 
+    public function countAllStartingFrom(int $startingFrom, string $uuid = null): int;
+
     public function persist(ShouldBeStored $event, string $uuid = null): StoredEvent;
 
     public function persistMany(array $events, string $uuid = null): LazyCollection;


### PR DESCRIPTION
LazyCollections count implementation iterates over all results. The replay command counts twice, so we end up iterating three times. By moving the count operation to the database and using the result in a variable we are able to get down to a single iteration.

Our system currently has around 300'000 stored events. To replay a projection, the command looped 600'000 times only to check if there are events and to display the progress bar, delaying the actual replay by several minutes.

This PR is aiming at version 1, because the upgrade to PHP 7.4 is planned later this year.