### PR TITLE
Only replace the first instance of the basePath

### DIFF
--- a/src/DiscoverEventHandlers.php
+++ b/src/DiscoverEventHandlers.php
@@ -70,7 +70,7 @@ class DiscoverEventHandlers
 
     private function fullQualifiedClassNameFromFile(SplFileInfo $file): string
     {
-        $class = trim(str_replace($this->basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+        $class = trim(Str::replaceFirst($this->basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
 
         $class = str_replace(
             [DIRECTORY_SEPARATOR, 'App\\'],


### PR DESCRIPTION
We use docker containers,
Our project sits at `/app` in the filesystem, meaning we have paths like `/app/app/Http/Controller.php`

With the current setup it was meaning the namespace of `\App\Http\Controllers\Controller` was becoming `\Http\Controllers\Controller`