### PR TITLE
add tests for datetime deserialization

### DIFF
--- a/src/EventSerializers/JsonEventSerializer.php
+++ b/src/EventSerializers/JsonEventSerializer.php
@@ -4,6 +4,7 @@ namespace Spatie\EventSourcing\EventSerializers;
 
 use Spatie\EventSourcing\ShouldBeStored;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 
@@ -14,7 +15,7 @@ class JsonEventSerializer implements EventSerializer
     public function __construct()
     {
         $encoders = [new JsonEncoder()];
-        $normalizers = [new ObjectNormalizer()];
+        $normalizers = [new DateTimeNormalizer(), new ObjectNormalizer()];
 
         $this->serializer = new SymfonySerializer($normalizers, $encoders);
     }

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -77,7 +77,7 @@ class EventSerializerTest extends TestCase
 
         $json = $this->eventSerializer->serialize($event);
 
-        $deserializeEvent = $this->eventSerializer->deserialize(EventWithDatetime::class, $json);
+        $deserializeEvent = $this->eventSerializer->deserialize(get_class($event), $json);
 
         $this->assertEquals($deserializeEvent, $event);
     }

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -77,8 +77,11 @@ class EventSerializerTest extends TestCase
 
         $json = $this->eventSerializer->serialize($event);
 
-        $deserializeEvent = $this->eventSerializer->deserialize(get_class($event), $json);
+        /**
+         * @var EventWithDatetime $normalizedEvent
+         */
+        $normalizedEvent = $this->eventSerializer->deserialize(get_class($event), $json);
 
-        $this->assertEquals($deserializeEvent, $event);
+        $this->assertInstanceOf(\DateTimeImmutable::class, $normalizedEvent->value);
     }
 }

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -4,6 +4,7 @@ namespace Spatie\EventSourcing\Tests\EventSerializers;
 
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\Tests\TestCase;
+use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithDatetime;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithoutSerializedModels;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
@@ -48,24 +49,14 @@ class EventSerializerTest extends TestCase
     }
 
     /** @test */
-    public function it_serializes_an_event_to_json()
+    public function it_can_deserialize_an_event_with_datetime()
     {
-        $account = Account::create();
-
-        $event = new MoneyAddedEvent($account, 1234);
+        $event = new EventWithDatetime(new \DateTimeImmutable('now'));
 
         $json = $this->eventSerializer->serialize($event);
 
-        $array = json_decode($json, true);
+        $deserializeEvent = $this->eventSerializer->deserialize(EventWithDatetime::class, $json);
 
-        $this->assertEquals([
-            'account' => [
-                'class' => get_class($account),
-                'id' => 1,
-                'relations' => [],
-                'connection' => $this->dbDriver(),
-            ],
-            'amount' => 1234,
-        ], $array);
+        $this->assertEquals($deserializeEvent, $event);
     }
 }

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -49,6 +49,28 @@ class EventSerializerTest extends TestCase
     }
 
     /** @test */
+    public function it_serializes_an_event_to_json()
+    {
+        $account = Account::create();
+
+        $event = new MoneyAddedEvent($account, 1234);
+
+        $json = $this->eventSerializer->serialize($event);
+
+        $array = json_decode($json, true);
+
+        $this->assertEquals([
+            'account' => [
+                'class' => get_class($account),
+                'id' => 1,
+                'relations' => [],
+                'connection' => $this->dbDriver(),
+            ],
+            'amount' => 1234,
+        ], $array);
+    }
+
+    /** @test */
     public function it_can_deserialize_an_event_with_datetime()
     {
         $event = new EventWithDatetime(new \DateTimeImmutable('now'));

--- a/tests/TestClasses/Events/EventWithDatetime.php
+++ b/tests/TestClasses/Events/EventWithDatetime.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Events;
+
+use Spatie\EventSourcing\ShouldBeStored;
+
+class EventWithDatetime implements ShouldBeStored
+{
+    public \DateTimeImmutable $value;
+
+    public function __construct(\DateTimeImmutable $value)
+    {
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
Run test as:
`vendor/bin/phpunit --filter EventSerializerTest`

You will notice the bug:

```
1) Spatie\EventSourcing\Tests\EventSerializers\EventSerializerTest::it_can_deserialize_an_event_with_datetime
Symfony\Component\Serializer\Exception\MissingConstructorArgumentsException: Cannot create an instance of DateTimeImmutable from serialized data because its constructor requires parameter "time" to be present.
```