### PR TITLE
Fixed event replay command docs

### DIFF
--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -13,16 +13,16 @@ All [events](/laravel-event-sourcing/v1/advanced-usage/preparing-events/) that i
  php artisan event-sourcing:replay
  ```
 
- You can also specify projectors by using the `--projector` option. All stored events will be passed only to that projector.
+ You can also specify projectors by using the projector name. All stored events will be passed only to that projector.
 
  ```bash
-  php artisan event-sourcing:replay --projector=App\\Projectors\\AccountBalanceProjector
+  php artisan event-sourcing:replay App\\Projectors\\AccountBalanceProjector
  ```
 
- You can use the projector option multiple times:
+ You can use the projector argument multiple times:
 
   ```bash
-   php artisan event-sourcing:replay --projector=App\\Projectors\\AccountBalanceProjector --projector=App\\Projectors\\AnotherProjector
+   php artisan event-sourcing:replay App\\Projectors\\AccountBalanceProjector App\\Projectors\\AnotherProjector
   ```
 
 If your projector has a `resetState` method it will get called before replaying events. You can use that method to reset the state of your projector.


### PR DESCRIPTION
The docs currently reference that the `--projector` option is available when replaying events. This has actually been changed to an option, therefore no `--projector` prefix required.

Looks like this change was introduced [here](https://github.com/spatie/laravel-event-sourcing/commit/fbb439093285522145ec4c9a8e5e70c268b4a0c7#diff-219d2a262b5ca12ebf45af61b8915600)