### PR TITLE
Remove the Final keyword from code generation examples

### DIFF
--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -21,7 +21,7 @@ namespace App\Aggregates;
 use Spatie\EventSourcing\AggregateRoot;
 
 
-final class MyAggregate extends AggregateRoot
+class MyAggregate extends AggregateRoot
 {
 }
 ```

--- a/docs/using-aggregates/writing-your-first-aggregate.md
+++ b/docs/using-aggregates/writing-your-first-aggregate.md
@@ -21,7 +21,7 @@ namespace App\Aggregates;
 use Spatie\EventSourcing\AggregateRoot;
 
 
-final class AccountAggregate extends AggregateRoot
+class AccountAggregate extends AggregateRoot
 {
 }
 ```
@@ -38,7 +38,7 @@ namespace App\Aggregates;
 use Spatie\EventSourcing\AggregateRoot;
 
 
-final class AccountAggregate extends AggregateRoot
+class AccountAggregate extends AggregateRoot
 {
     public function createAccount(string $name, string $userId)
     {


### PR DESCRIPTION
I removed the Final keyword from the examples in the docs for using the CLI to generate aggregates as the stubs no longer uses Final.