### PR TITLE
Add applied events support

### DIFF
--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -95,7 +95,7 @@ abstract class AggregateRoot
 
     public function getAppliedEvents(): array
     {
-        return $this->recordedEvents;
+        return $this->appliedEvents;
     }
 
     protected function getState(): array

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -16,6 +16,8 @@ abstract class AggregateRoot
 
     private array $recordedEvents = [];
 
+    private array $appliedEvents = [];
+
     protected int $aggregateVersion = 0;
 
     protected int $aggregateVersionAfterReconstitution = 0;
@@ -87,6 +89,11 @@ abstract class AggregateRoot
     }
 
     public function getRecordedEvents(): array
+    {
+        return $this->recordedEvents;
+    }
+
+    public function getAppliedEvents(): array
     {
         return $this->recordedEvents;
     }
@@ -167,6 +174,8 @@ abstract class AggregateRoot
         if (method_exists($this, $applyingMethodName)) {
             $this->$applyingMethodName($event);
         }
+
+        $this->appliedEvents[] = $event;
 
         $this->aggregateVersion++;
     }

--- a/src/FakeAggregateRoot.php
+++ b/src/FakeAggregateRoot.php
@@ -42,7 +42,7 @@ class FakeAggregateRoot
 
     public function assertNothingRecorded(): self
     {
-        Assert::assertCount(0, $this->aggregateRoot->getAppliedEvents());
+        Assert::assertCount(0, $this->aggregateRoot->getRecordedEvents());
 
         return $this;
     }
@@ -62,7 +62,7 @@ class FakeAggregateRoot
             unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
 
             return $event->setMetaData($metaData);
-        }, $this->aggregateRoot->getAppliedEvents());
+        }, $this->aggregateRoot->getRecordedEvents());
 
         Assert::assertEquals($expectedEvents, $recordedEvents);
 
@@ -71,12 +71,52 @@ class FakeAggregateRoot
 
     public function assertNotRecorded($unexpectedEventClasses): void
     {
-        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->aggregateRoot->getAppliedEvents());
+        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->aggregateRoot->getRecordedEvents());
 
         $unexpectedEventClasses = Arr::wrap($unexpectedEventClasses);
 
         foreach ($unexpectedEventClasses as $nonExceptedEventClass) {
             Assert::assertNotContains($nonExceptedEventClass, $actualEventClasses, "Did not expect to record {$nonExceptedEventClass}, but it was recorded.");
+        }
+    }
+
+    public function assertNothingApplied(): self
+    {
+        Assert::assertCount(0, $this->aggregateRoot->getAppliedEvents());
+
+        return $this;
+    }
+
+    /**
+     * @param \Spatie\EventSourcing\ShouldBeStored|\Spatie\EventSourcing\ShouldBeStored[] $expectedEvents
+     *
+     * @return $this
+     */
+    public function assertApplied($expectedEvents): self
+    {
+        $expectedEvents = Arr::wrap($expectedEvents);
+
+        $appliedEvents = array_map(function(ShouldBeStored $event) {
+            $metaData = $event->metaData();
+
+            unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
+
+            return $event->setMetaData($metaData);
+        }, $this->aggregateRoot->getAppliedEvents());
+
+        Assert::assertEquals($expectedEvents, $appliedEvents);
+
+        return $this;
+    }
+
+    public function assertNotApplied($unexpectedEventClasses): void
+    {
+        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->aggregateRoot->getAppliedEvents());
+
+        $unexpectedEventClasses = Arr::wrap($unexpectedEventClasses);
+
+        foreach ($unexpectedEventClasses as $nonExceptedEventClass) {
+            Assert::assertNotContains($nonExceptedEventClass, $actualEventClasses, "Did not expect to apply {$nonExceptedEventClass}, but it was applied.");
         }
     }
 

--- a/src/FakeAggregateRoot.php
+++ b/src/FakeAggregateRoot.php
@@ -42,7 +42,7 @@ class FakeAggregateRoot
 
     public function assertNothingRecorded(): self
     {
-        Assert::assertCount(0, $this->aggregateRoot->getRecordedEvents());
+        Assert::assertCount(0, $this->aggregateRoot->getAppliedEvents());
 
         return $this;
     }
@@ -62,7 +62,7 @@ class FakeAggregateRoot
             unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
 
             return $event->setMetaData($metaData);
-        }, $this->aggregateRoot->getRecordedEvents());
+        }, $this->aggregateRoot->getAppliedEvents());
 
         Assert::assertEquals($expectedEvents, $recordedEvents);
 
@@ -71,7 +71,7 @@ class FakeAggregateRoot
 
     public function assertNotRecorded($unexpectedEventClasses): void
     {
-        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->aggregateRoot->getRecordedEvents());
+        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->aggregateRoot->getAppliedEvents());
 
         $unexpectedEventClasses = Arr::wrap($unexpectedEventClasses);
 

--- a/tests/FakeAggregateRootTest.php
+++ b/tests/FakeAggregateRootTest.php
@@ -113,4 +113,10 @@ class FakeAggregateRootTest extends TestCase
 
         DummyAggregateRoot::fake()->assertNotApplied([DummyEvent::class]);
     }
+
+    /** @test */
+    public function it_can_assert_that_noting_is_applied()
+    {
+        DummyAggregateRoot::fake()->assertNothingApplied();
+    }
 }

--- a/tests/FakeAggregateRootTest.php
+++ b/tests/FakeAggregateRootTest.php
@@ -30,6 +30,26 @@ class FakeAggregateRootTest extends TestCase
     }
 
     /** @test */
+    public function it_can_assert_the_applied_events()
+    {
+        DummyAggregateRoot::fake()
+            ->given([
+                new DummyEvent(1),
+                new DummyEvent(2),
+            ])
+            ->when(function (DummyAggregateRoot $dummyAggregateRoot) {
+                $dummyAggregateRoot->dummy();
+
+                $dummyAggregateRoot->persist();
+            })
+            ->assertApplied([
+                new DummyEvent(1),
+                new DummyEvent(2),
+                new DummyEvent(3),
+            ]);
+    }
+
+    /** @test */
     public function it_can_assert_recorded_events_without_using_when()
     {
         /** @var \Spatie\EventSourcing\Tests\TestClasses\DummyAggregateRoot|\Spatie\EventSourcing\FakeAggregateRoot $fakeAggregateRoot */
@@ -84,5 +104,13 @@ class FakeAggregateRootTest extends TestCase
         DummyAggregateRoot::fake()->assertNotRecorded(DummyEvent::class);
 
         DummyAggregateRoot::fake()->assertNotRecorded([DummyEvent::class]);
+    }
+
+    /** @test */
+    public function it_can_assert_that_an_event_is_not_applied()
+    {
+        DummyAggregateRoot::fake()->assertNotApplied(DummyEvent::class);
+
+        DummyAggregateRoot::fake()->assertNotApplied([DummyEvent::class]);
     }
 }


### PR DESCRIPTION
Calling `persist` on an aggregate root will clear the `recordedEvents` array. This means that if you're calling persists within a faked aggregate root, assertions will fail because the recorded events array is empty. 

I'd suggest to keep track of all applied events as well, which will never get cleared. 