### PR TITLE
Update UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,6 +17,7 @@ Nothing changed, expect that where possible property types and short closures ar
 The only change in this version is the naming change from `laravel-event-projector` to `laravel-event-sourcing`. There are no changes to the API.
 
 To upgrade from v3 of `laravel-event-projector` you have to perform these steps:
-1. Rename `config/event-projector.php` to `config/event-sourcing.php`
-2. Change `laravel-event-projector:v3` to `laravel-event-sourcing:v1` and run `composer update`
-3. The namespace has changed, so you need to replace `Spatie\EventProjector` by `Spatie\EventSourcing` in your entire project
+1. Merge the `config/event-projector.php` with `vendor/spatie/laravel-event-sourcing/config/event-sourcing.php` 
+2. Rename `config/event-projector.php` to `config/event-sourcing.php`
+3. Change `laravel-event-projector:v3` to `laravel-event-sourcing:v1` and run `composer update`
+4. The namespace has changed, so you need to replace `Spatie\EventProjector` by `Spatie\EventSourcing` in your entire project


### PR DESCRIPTION
In the middle of the upgrading process, I've encountered `Spatie\EventSourcing\AggregateRoot::getSnapshotRepository() must be an instance of Spatie\EventSourcing\Snapshots\SnapshotRepository, instance of Laravel\Lumen\Application returned` error, so I found out some configs are missing.