### PR TITLE
Only include public properties of the aggregate when snapshotting

### DIFF
--- a/docs/using-aggregates/snapshots.md
+++ b/docs/using-aggregates/snapshots.md
@@ -33,12 +33,11 @@ protected function getState(): array
 {
     $class = new ReflectionClass($this);
 
-    return collect($class->getProperties())
+    return collect($class->getProperties(ReflectionProperty::IS_PUBLIC))
         ->reject(fn (ReflectionProperty $reflectionProperty) => $reflectionProperty->isStatic())
         ->mapWithKeys(function (ReflectionProperty $property) {
             return [$property->getName() => $this->{$property->getName()}];
-        })
-        ->toArray();
+        })->toArray();
 }
 ```
 

--- a/src/AggregateRoot.php
+++ b/src/AggregateRoot.php
@@ -93,7 +93,7 @@ abstract class AggregateRoot
     {
         $class = new ReflectionClass($this);
 
-        return collect($class->getProperties())
+        return collect($class->getProperties(ReflectionProperty::IS_PUBLIC))
             ->reject(fn (ReflectionProperty $reflectionProperty) => $reflectionProperty->isStatic())
             ->mapWithKeys(function (ReflectionProperty $property) {
                 return [$property->getName() => $this->{$property->getName()}];


### PR DESCRIPTION
Otherwise properties like `aggregateVersion` and `aggregateVersionAfterReconstitution` are getting into the event properties.