### PR TITLE
Pass metadata to serializer to allow events to be upgraded

### DIFF
--- a/docs/advanced-usage/using-your-own-event-serializer.md
+++ b/docs/advanced-usage/using-your-own-event-serializer.md
@@ -18,6 +18,31 @@ interface EventSerializer
 {
     public function serialize(ShouldBeStored $event): string;
 
-    public function deserialize(string $eventClass, string $json): ShouldBeStored;
+    public function deserialize(string $eventClass, string $json, string $metadata): ShouldBeStored;
 }
 ```
+
+## Upgrading Events
+
+If an event payload has changed overtime, old events can be "upgraded" to the new payload on the fly
+in the event serializer. 
+
+Using our larabank example, let's imagine that we've gone international and our new accepting 
+international payments. Our `MoneyAdded` events will need to have an additional field for
+the currency.
+
+```
+class UpgradeSerializer extends JsonEventSerializer
+{
+    public function deserialize(string $eventClass, string $json, string $metadata = null): ShouldBeStored
+    {
+        $event = parent::deserialize($eventClass, $json, $metadata);
+
+        // all currency was USD before we started accepting other currencies
+        if (empty($event->currency)) {
+            $event->currency = 'USD';
+        }
+
+        return $event;
+    }
+}

--- a/src/EventSerializers/EventSerializer.php
+++ b/src/EventSerializers/EventSerializer.php
@@ -8,5 +8,5 @@ interface EventSerializer
 {
     public function serialize(ShouldBeStored $event): string;
 
-    public function deserialize(string $eventClass, string $json): ShouldBeStored;
+    public function deserialize(string $eventClass, string $json, string $metadata = null): ShouldBeStored;
 }

--- a/src/StoredEvent.php
+++ b/src/StoredEvent.php
@@ -41,7 +41,10 @@ class StoredEvent implements Arrayable
                 self::getActualClassForEvent($this->event_class),
                 is_string($this->event_properties)
                     ? $this->event_properties
-                    : json_encode($this->event_properties)
+                    : json_encode($this->event_properties),
+                is_string($this->meta_data)
+                    ? $this->meta_data
+                    : json_encode($this->meta_data),
             );
 
             $this->event->setMetaData(optional($this->meta_data)->toArray());

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -99,8 +99,6 @@ class EventSerializerTest extends TestCase
          */
         $normalizedEvent = $eventSerializer->deserialize(get_class($event), $json, '{ "version": 1 }');
 
-        dump($normalizedEvent);
-
         $this->assertInstanceOf(\DateTimeImmutable::class, $normalizedEvent->value);
         $this->assertEquals('UTC', $normalizedEvent->value->getTimezone()->getName());
     }

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -7,6 +7,7 @@ use Spatie\EventSourcing\Tests\TestCase;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithDatetime;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithoutSerializedModels;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
+use Spatie\EventSourcing\Tests\TestClasses\EventSerializer\UpgradeSerializer;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
 
 class EventSerializerTest extends TestCase
@@ -83,5 +84,24 @@ class EventSerializerTest extends TestCase
         $normalizedEvent = $this->eventSerializer->deserialize(get_class($event), $json);
 
         $this->assertInstanceOf(\DateTimeImmutable::class, $normalizedEvent->value);
+    }
+
+    /** @test */
+    public function it_can_upgrade_an_event_version()
+    {
+        $event = new EventWithDatetime(new \DateTimeImmutable('2019-08-07T00:00:00Z'));
+        $eventSerializer = app(UpgradeSerializer::class);
+
+        $json = $eventSerializer->serialize($event);
+
+        /**
+         * @var EventWithDatetime
+         */
+        $normalizedEvent = $eventSerializer->deserialize(get_class($event), $json, '{ "version": 1 }');
+
+        dump($normalizedEvent);
+
+        $this->assertInstanceOf(\DateTimeImmutable::class, $normalizedEvent->value);
+        $this->assertEquals('UTC', $normalizedEvent->value->getTimezone()->getName());
     }
 }

--- a/tests/TestClasses/EventSerializer/UpgradeSerializer.php
+++ b/tests/TestClasses/EventSerializer/UpgradeSerializer.php
@@ -1,14 +1,17 @@
 <?php
 
-namespace Spatie\EventSourcing\EventSerializers;
+namespace Spatie\EventSourcing\Tests\TestClasses\EventSerializer;
 
+use DateTimeZone;
+use Spatie\EventSourcing\EventSerializers\EventSerializer;
+use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;
 use Spatie\EventSourcing\ShouldBeStored;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 
-class JsonEventSerializer implements EventSerializer
+class UpgradeSerializer implements EventSerializer
 {
     private SymfonySerializer $serializer;
 
@@ -39,10 +42,11 @@ class JsonEventSerializer implements EventSerializer
     {
         $restoredEvent = $this->serializer->deserialize($json, $eventClass, 'json');
 
-        /*
-         *  We call manually serialize and unserialize to trigger
-         * `Illuminate\Queue\SerializesModels` model restoring capabilities.
-         */
+        $metadata = json_decode($metadata, true);
+        if ($metadata['version'] < 2) {
+            $restoredEvent->value = $restoredEvent->value->setTimezone(new DateTimeZone('UTC'));
+        }
+
         return unserialize(serialize($restoredEvent));
     }
 }

--- a/tests/TestClasses/EventSerializer/UpgradeSerializer.php
+++ b/tests/TestClasses/EventSerializer/UpgradeSerializer.php
@@ -11,42 +11,17 @@ use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
 use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 
-class UpgradeSerializer implements EventSerializer
+class UpgradeSerializer extends JsonEventSerializer
 {
-    private SymfonySerializer $serializer;
-
-    public function __construct()
-    {
-        $encoders = [new JsonEncoder()];
-        $normalizers = [new DateTimeNormalizer(), new ObjectNormalizer()];
-
-        $this->serializer = new SymfonySerializer($normalizers, $encoders);
-    }
-
-    public function serialize(ShouldBeStored $event): string
-    {
-        /*
-         * We call __sleep so `Illuminate\Queue\SerializesModels` will
-         * prepare all models in the event for serialization.
-         */
-        if (method_exists($event, '__sleep')) {
-            $event->__sleep();
-        }
-
-        $json = $this->serializer->serialize($event, 'json');
-
-        return $json;
-    }
-
     public function deserialize(string $eventClass, string $json, string $metadata = null): ShouldBeStored
     {
-        $restoredEvent = $this->serializer->deserialize($json, $eventClass, 'json');
+        $event = parent::deserialize($eventClass, $json, $metadata);
 
         $metadata = json_decode($metadata, true);
         if ($metadata['version'] < 2) {
-            $restoredEvent->value = $restoredEvent->value->setTimezone(new DateTimeZone('UTC'));
+            $event->value = $event->value->setTimezone(new DateTimeZone('UTC'));
         }
 
-        return unserialize(serialize($restoredEvent));
+        return $event;
     }
 }


### PR DESCRIPTION
This is a first pass suggestion on how to implement an upgrade backwards compatible event versions. 

For example if we had an event like `AccountCreated` and stored the open date as `2019-03-43 12:30:00`. This event payload is v1. 

In later versions of the app, we're going international and so the open date now needs a timezone attached to it like `2019-03-43 12:30:00 +00:00`.

We change the code to include the timezone and it's now v2 of the event payload. 

When we replay events we expect the latest version of the event payload in order to function correctly. This PR allows the event serializer to upgrade the event live so it can be transformed to the latest version.