### PR TITLE
Fixed the docs for addReactors and addProjectors

### DIFF
--- a/docs/advanced-usage/adding-and-removing-projectors-and-reactors.md
+++ b/docs/advanced-usage/adding-and-removing-projectors-and-reactors.md
@@ -18,7 +18,7 @@ Projectionist::addProjector(TransactionCountProjector::class);
 Adding multiple projectors:
 
 ```php
-Projectionist::addProjector([
+Projectionist::addProjectors([
     AccountBalanceProjector::class,
     TransactionCountProjector::class,
 ]);
@@ -35,7 +35,7 @@ Projectionist::addReactor(SendMailReactor::class);
 Adding multiple reactors:
 
 ```php
-Projectionist::addReactor([
+Projectionist::addReactors([
     SendMailReactor::class,
     SendPushNotificationReactor::class,
 ]);


### PR DESCRIPTION
The singular method name was used, while this should be the plural method name.