### PR TITLE
Replace model where clause with uuid model scope

### DIFF
--- a/src/EloquentStoredEventRepository.php
+++ b/src/EloquentStoredEventRepository.php
@@ -110,7 +110,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
     public function getLatestAggregateVersion(string $aggregateUuid): int
     {
         return $this->storedEventModel::query()
-            ->where('aggregate_uuid', $aggregateUuid)
+            ->uuid($aggregateUuid)
             ->max('aggregate_version') ?? 0;
     }
 


### PR DESCRIPTION
Make EloquentStoredEventRepository consistently use the uuid model scope for queries.

This allows for overriding the scope for use cases such as using the efficientUuid package