### PR TITLE
Default to BigIncrements on package table stubs

### DIFF
--- a/stubs/create_snapshots_table.php.stub
+++ b/stubs/create_snapshots_table.php.stub
@@ -9,7 +9,7 @@ class CreateSnapshotsTable extends Migration
     public function up()
     {
         Schema::create('snapshots', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->uuid('aggregate_uuid');
             $table->unsignedInteger('aggregate_version');
             $table->json('state');

--- a/stubs/create_stored_events_table.php.stub
+++ b/stubs/create_stored_events_table.php.stub
@@ -9,7 +9,7 @@ class CreateStoredEventsTable extends Migration
     public function up()
     {
         Schema::create('stored_events', function (Blueprint $table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->uuid('aggregate_uuid')->nullable();
             $table->unsignedBigInteger('aggregate_version')->nullable();
             $table->string('event_class');


### PR DESCRIPTION
Ensures many more events and snapshots can be recorded before an int overflow error occurs.

Also bring it inline with the default int type for Laravel 7 id column types.

Regular unsigned int is not large enough for event heavy Event Sourced systems.