### PR TITLE
Support for Lumen

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -32,7 +32,7 @@ return [
      * will be automatically registered to projectionist automatically.
      */
     'auto_discover_projectors_and_reactors' => [
-        app_path(),
+        app('path'),
     ],
 
     /*


### PR DESCRIPTION
Lumen doesn't have function to get app_path(), but there are following workarounds:

```php
app()->path();
app('path');
base_path('app');
```