### PR TITLE
Updates implementation of how to queue a projector

### DIFF
--- a/docs/using-projectors/making-sure-events-get-handled-in-the-right-order.md
+++ b/docs/using-projectors/making-sure-events-get-handled-in-the-right-order.md
@@ -7,9 +7,9 @@ By default all events are handled in a synchronous manner. This means that if yo
 
 ## Handling events in a queue
 
-A queue can be used to guarantee that all events get passed to projectors in the right order. If you want a projector to handle events in a queue, you should let your projector implement the `Spatie\EventSourcing\Projectors\QueuedProjector` interface instead of the the normal `Spatie\EventSourcing\Projectors\Projector`. This interface merely hints to the `Projectionist` that the event handling should happen in a queued manner.
+A queue can be used to guarantee that all events get passed to projectors in the right order. If you want a projector to handle events in a queue then simply add the `Illuminate\Contracts\Queue\ShouldQueue` interface to your projector just like you would a Job. 
 
-A useful rule of thumb is that if your projectors aren't producing data that is consumed in the same request as the events are fired, you should let your projector implement `QueuedProjector`.
+A useful rule of thumb is that if your projectors aren't producing data that is consumed in the same request as the events are fired, you should let your projector implement `Illuminate\Contracts\Queue\ShouldQueue`.
 
 You can set the name of the queue connection in the `queue` key of the `event-sourcing` config file.  You should make sure that the queue will process only one job at a time.
 


### PR DESCRIPTION
Whilst pulling down v4 and having a play around I realised at the queuing section of the documentation was still at v2. If I find anything else I'll drop it in this morning. I won't be offended if you want to reword it 👍 