### PR TITLE
Update Readme with Link to open the doc's introduction directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 This package aims to be the entry point to get started with event sourcing in Laravel. It can help you with setting up aggregates, projectors, and reactors. 
 
-If you've never worked with event sourcing, or are uncertain about what aggregates, projectors and reactors are head over to the getting familiar with event sourcing section [in our docs](https://docs.spatie.be/laravel-event-sourcing/v4).
+If you've never worked with event sourcing, or are uncertain about what aggregates, projectors and reactors are head over to the getting familiar with event sourcing section [in our docs](https://docs.spatie.be/laravel-event-sourcing/v4/introduction).
 
 Event sourcing might be a good choice for your project if:
 


### PR DESCRIPTION
A simple suggestion: the link to the documentation may benefit from the introduction part of the document Because navigating to https://docs.spatie.be/laravel-event-sourcing/v4 simply opens the document's blank section but, https://docs.spatie.be/laravel-event-sourcing/v4/introduction opens the introduction directly.

This PR makes the little change to the link in the Readme.md file.

> PS: I am not sure what branch is appropriate to make the Pull Request to, this is why I chose master.