### PR TITLE
Add assertion that specific event is recorded

### DIFF
--- a/docs/using-aggregates/testing-aggregates.md
+++ b/docs/using-aggregates/testing-aggregates.md
@@ -88,6 +88,8 @@ public function it_will_not_make_subtractions_that_would_go_below_the_account_li
 
 The `given` and `assertRecorded` methods can accept a single event instances or an array with event instances. `assertNotRecorded` can also accept an array of class names.
 
+When you'd like to assert that only a specific event is recorded, you can use the `assertEventRecorded` method.
+
 If you don't expect any events to be recorded you can use `assertNothingRecorded`.
 
 ## Disabling dispatching events

--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -57,13 +57,7 @@ class FakeAggregateRoot
     {
         $expectedEvents = Arr::wrap($expectedEvents);
 
-        $recordedEvents = array_map(function (ShouldBeStored $event) {
-            $metaData = $event->metaData();
-
-            unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
-
-            return $event->setMetaData($metaData);
-        }, $this->aggregateRoot->getRecordedEvents());
+        $recordedEvents = $this->getRecordedEventsWithoutUuid();
 
         Assert::assertEquals($expectedEvents, $recordedEvents);
 
@@ -79,6 +73,14 @@ class FakeAggregateRoot
         foreach ($unexpectedEventClasses as $nonExceptedEventClass) {
             Assert::assertNotContains($nonExceptedEventClass, $actualEventClasses, "Did not expect to record {$nonExceptedEventClass}, but it was recorded.");
         }
+    }
+
+    public function assertEventRecorded(ShouldBeStored $expectedEvent): self {
+        $recordedEvents = $this->getRecordedEventsWithoutUuid();
+
+        Assert::assertContainsEquals($expectedEvent, $recordedEvents);
+
+        return $this;
     }
 
     public function assertNothingApplied(): self
@@ -131,5 +133,16 @@ class FakeAggregateRoot
     public function aggregateRoot(): AggregateRoot
     {
         return $this->aggregateRoot;
+    }
+
+    private function getRecordedEventsWithoutUuid(): array
+    {
+        return array_map(static function (ShouldBeStored $event) {
+            $metaData = $event->metaData();
+
+            unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
+
+            return $event->setMetaData($metaData);
+        }, $this->aggregateRoot->getRecordedEvents());
     }
 }

--- a/tests/FakeAggregateRootTest.php
+++ b/tests/FakeAggregateRootTest.php
@@ -92,6 +92,21 @@ class FakeAggregateRootTest extends TestCase
     }
 
     /** @test */
+    public function it_can_assert_an_specific_event_is_recorded_when_multiple_events_are_fired()
+    {
+        DummyAggregateRoot::fake()
+            ->given([
+                new DummyEvent(1),
+                new DummyEvent(2),
+            ])
+            ->when(function (DummyAggregateRoot $dummyAggregateRoot) {
+                $dummyAggregateRoot->dummy();
+                $dummyAggregateRoot->dummy();
+            })
+            ->assertEventRecorded(new DummyEvent(3));
+    }
+
+    /** @test */
     public function it_can_assert_that_an_event_is_not_recorded()
     {
         DummyAggregateRoot::fake()->assertNotRecorded(DummyEvent::class);


### PR DESCRIPTION
Sometimes you'd like to test if a specific event is fired from the method of an aggregate, without caring about other events that the method might fire. For this, I've added a `assertEventRecorded` to the fake aggregate root. 

So we could use: 

`->assertEventRecorded(new DummyEvent(3));`

While `DummyEvent(4)` is also fired from the same method. 