### PR TITLE
Allow events to be dispatched from an aggregate root

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -107,8 +107,9 @@ return [
     'cache_path' => storage_path('app/event-sourcing'),
 
     /*
-    * Configure if events recorded in an aggregate root are dispatched on the Laravel event bus.
-    */
+     * When storable evens are fired from aggregates roots, the package can fire off these
+     * events as regular events as well.
+     */
 
     'dispatch_events_from_aggregate_roots' => false,
 ];

--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -107,7 +107,7 @@ return [
     'cache_path' => storage_path('app/event-sourcing'),
 
     /*
-    * Configure if events recorded in a aggregate root are dispatched on the Laravel event bus.
+    * Configure if events recorded in an aggregate root are dispatched on the Laravel event bus.
     */
 
     'dispatch_events_from_aggregate_roots' => false,

--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -105,4 +105,10 @@ return [
      * Here you can specify where the cache should be stored.
      */
     'cache_path' => storage_path('app/event-sourcing'),
+
+    /*
+    * Configure if events recorded in a aggregate root are dispatched on the Laravel event bus.
+    */
+
+    'dispatch_events_from_aggregate_roots' => false,
 ];

--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -83,4 +83,4 @@ MyAggregate::retrieve($uuid) // will cause all events for this uuid to be fed to
 
 Persisting an aggregate root will write all newly recorded events to the database. The newly persisted events will get passed to all projectors and reactors.
 
-By default, the event won't be fired on Laravels event bus. To dispatch events when they are stored, you can set the `dispatch_events_from_aggregate_roots` value in the `event-sourcing.php` config file to true. 
+By default, the event won't be fired on Laravels event bus. To dispatch events when they are stored, you can set the `dispatch_events_from_aggregate_roots` value in the `event-sourcing` config file to `true`. 

--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -82,3 +82,5 @@ MyAggregate::retrieve($uuid) // will cause all events for this uuid to be fed to
 ```
 
 Persisting an aggregate root will write all newly recorded events to the database. The newly persisted events will get passed to all projectors and reactors.
+
+By default, the event won't be fired on Laravels event bus. To dispatch events when they are stored, you can set the `dispatch_events_from_aggregate_roots` value in the `event-sourcing.php` config file to true. 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -71,7 +71,7 @@ abstract class AggregateRoot
     {
         $storedEvents = $this->persistWithoutApplyingToEventHandlers();
 
-        $storedEvents->each(fn (StoredEvent $storedEvent) => $storedEvent->handle());
+        $storedEvents->each(fn (StoredEvent $storedEvent) => $storedEvent->handleForAggregateRoot());
 
         $this->aggregateVersionAfterReconstitution = $this->aggregateVersion;
 

--- a/src/StoredEvents/EventSubscriber.php
+++ b/src/StoredEvents/EventSubscriber.php
@@ -24,6 +24,10 @@ class EventSubscriber
             return;
         }
 
+        if ($this->isFiredFromAggregateRoot($payload[0])) {
+            return;
+        }
+
         $this->storeEvent($payload[0]);
     }
 
@@ -40,5 +44,10 @@ class EventSubscriber
         }
 
         return is_subclass_of($event, ShouldBeStored::class);
+    }
+
+    private function isFiredFromAggregateRoot($event): bool
+    {
+        return $event->firedFromAggregateRoot ?? false;
     }
 }

--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -69,6 +69,17 @@ class StoredEvent implements Arrayable
         ];
     }
 
+    public function handleForAggregateRoot(): void
+    {
+        $this->handle();
+
+        if (! config('event-sourcing.dispatch_events_from_aggregate_roots', false)) {
+            return;
+        }
+
+        $this->event->firedFromAggregateRoot = true;
+        event($this->event);
+    }
     public function handle()
     {
         Projectionist::handleWithSyncEventHandlers($this);

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -372,7 +372,7 @@ class AggregateRootTest extends TestCase
             ->addMoney(100)
             ->persist();
 
-        Event::assertDispatched(function (MoneyAdded $event) {
+        Event::assertDispatched(MoneyAdded::class, function (MoneyAdded $event) {
             $this->assertEquals(100, $event->amount);
             $this->assertTrue($event->firedFromAggregateRoot);
             return true;

--- a/tests/EventSubscriberTest.php
+++ b/tests/EventSubscriberTest.php
@@ -78,6 +78,17 @@ class EventSubscriberTest extends TestCase
     }
 
     /** @test */
+    public function it_will_not_store_events_when_events_are_fired_from_a_aggregate_root()
+    {
+        $event = new MoneyAddedEvent($this->account, 1234);
+        $event->firedFromAggregateRoot = true;
+
+        event($event);
+
+        $this->assertCount(0, EloquentStoredEvent::get());
+    }
+
+    /** @test */
     public function it_will_call_registered_projectors()
     {
         Projectionist::addProjector(BalanceProjector::class);


### PR DESCRIPTION
Currently when an event is recorded from within an aggregate root, it is not dispatched on Laravel's event bus. 

 This non breaking, configurable change would allow for aggregate roots to dispatch the events when the events are persisted.