### PR TITLE
Support Carbon dates in events

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "spatie/laravel-schemaless-attributes": "^1.6",
         "symfony/finder": "^4.2|^5.0",
         "symfony/property-access": "^4.0|^5.0",
-        "symfony/serializer": "^4.0|^5.0"
+        "symfony/serializer": "^5.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.16",

--- a/src/EventSerializers/JsonEventSerializer.php
+++ b/src/EventSerializers/JsonEventSerializer.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventSourcing\EventSerializers;
 
+use Spatie\EventSourcing\Support\CarbonNormalizer;
 use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 use Symfony\Component\Serializer\Normalizer\DateTimeNormalizer;
@@ -15,7 +16,7 @@ class JsonEventSerializer implements EventSerializer
     public function __construct()
     {
         $encoders = [new JsonEncoder()];
-        $normalizers = [new DateTimeNormalizer(), new ObjectNormalizer()];
+        $normalizers = [new CarbonNormalizer(), new DateTimeNormalizer(), new ObjectNormalizer()];
 
         $this->serializer = new SymfonySerializer($normalizers, $encoders);
     }

--- a/src/Support/CarbonNormalizer.php
+++ b/src/Support/CarbonNormalizer.php
@@ -19,7 +19,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
             throw new InvalidArgumentException('Cannot serialize an object that is not a CarbonInterface in CarbonNormalizer.');
         }
 
-        return $object->toISOString();
+        return $object->toRfc3339String();
     }
 
     /**

--- a/src/Support/CarbonNormalizer.php
+++ b/src/Support/CarbonNormalizer.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Spatie\EventSourcing\Support;
+
+use Carbon\CarbonInterface;
+use InvalidArgumentException;
+use Illuminate\Support\Facades\Date;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    /**
+     * @inheritdoc
+     */
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        if (! $object instanceof CarbonInterface) {
+            throw new InvalidArgumentException('Cannot serialize an object that is not a CarbonInterface in CarbonNormalizer.');
+        }
+
+        return $object->toISOString();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function supportsNormalization($data, string $format = null)
+    {
+        return $data instanceof CarbonInterface;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function denormalize($data, $class, string $format = null, array $context = [])
+    {
+        return Date::parse($data);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function supportsDenormalization($data, $type, string $format = null)
+    {
+        return is_a($type, CarbonInterface::class, true);
+    }
+}

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -2,8 +2,11 @@
 
 namespace Spatie\EventSourcing\Tests\EventSerializers;
 
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\Tests\TestCase;
+use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithCarbon;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithDatetime;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithoutSerializedModels;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
@@ -84,6 +87,18 @@ class EventSerializerTest extends TestCase
         $normalizedEvent = $this->eventSerializer->deserialize(get_class($event), $json);
 
         $this->assertInstanceOf(\DateTimeImmutable::class, $normalizedEvent->value);
+    }
+
+    /** @test */
+    public function it_can_deserialize_an_event_with_carbon()
+    {
+        $event = new EventWithCarbon(Carbon::now());
+
+        $json = $this->eventSerializer->serialize($event);
+
+        $normalizedEvent = $this->eventSerializer->deserialize(get_class($event), $json);
+
+        $this->assertInstanceOf(CarbonInterface::class, $normalizedEvent->value);
     }
 
     /** @test */

--- a/tests/TestClasses/Events/EventWithCarbon.php
+++ b/tests/TestClasses/Events/EventWithCarbon.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Events;
+
+use Carbon\CarbonInterface;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class EventWithCarbon extends ShouldBeStored
+{
+    public CarbonInterface $value;
+
+    public function __construct(CarbonInterface $value)
+    {
+        $this->value = $value;
+    }
+}


### PR DESCRIPTION
Using `Carbon` dates in events doesn't currently work out of the box. The current implementation of the DateTimeNormalizer only allows you to use PHP's `DateTime` which misses out on some useful Carbon functionalities. To use Carbon dates, you need to implement your own [`EventSerializer`](https://github.com/spatie/laravel-event-sourcing/blob/master/src/EventSerializers/EventSerializer.php) and add a `Normalizer` that supports the (de)normalization of Carbon instances.

As the standard date implementation is Carbon and this package is built for Laravel, I would like to suggest to include a `CarbonNormalizer` to improve the developer experience for those who use Carbon datetimes in their events.