### PR TITLE
add down routine to snapshots and stored_events migration stubs

### DIFF
--- a/stubs/create_snapshots_table.php.stub
+++ b/stubs/create_snapshots_table.php.stub
@@ -19,4 +19,9 @@ class CreateSnapshotsTable extends Migration
             $table->index('aggregate_uuid');
         });
     }
+	
+    public function down()
+    {
+        Schema::dropIfExists('snapshots');
+    }
 }

--- a/stubs/create_stored_events_table.php.stub
+++ b/stubs/create_stored_events_table.php.stub
@@ -20,4 +20,9 @@ class CreateStoredEventsTable extends Migration
             $table->index('aggregate_uuid');
         });
     }
+	
+    public function down()
+    {
+        Schema::dropIfExists('stored_events');
+    }
 }


### PR DESCRIPTION
without those down routines `php artisan migrate:refresh` will fail since the tables for `stored_events` and `snapshots` are already present during migration