### PR TITLE
Add stored event repository as parameter in replay command

### DIFF
--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -29,10 +29,10 @@ If your projector has a `resetState` method it will get called before replaying 
 
 If you want to replay events starting from a certain event you can use the `--from` option when executing `event-sourcing:replay`. If you use this option the `resetState` on projectors will not get called. This package does not track which events have already been processed by which projectors. Be sure not to replay events to projectors that already have handled them.
 
-If you are [using your own event storage model](/laravel-event-sourcing/v4/advanced-usage/using-your-own-event-storage-model/) then you will need to use the `--stored-event-model` option when executing `event-sourcing:replay` to specify the model storing the events you want to replay.
+If you are [using your own event storage repository](/laravel-event-sourcing/v4/advanced-usage/using-your-own-event-storage-repository/) then you will need to use the `--stored-event-repository` option when executing `event-sourcing:replay` to specify the repository storing the events you want to replay.
 
 ```bash
-php artisan event-sourcing:replay --stored-event-model=App\\Models\\AccountStoredEvent
+php artisan event-sourcing:replay --stored-event-repository=App\\Repositories\\CustomEloquentStoredEventRepository
  ```
 
 ## Detecting event replays

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -103,7 +103,7 @@ class ReplayCommand extends Command
 
         if (! is_subclass_of($storedEventRepository, StoredEventRepository::class)) {
             throw new InvalidArgumentException(
-                "Stored event model class `$storedEventRepository` does not implement `" . StoredEventRepository::class . '`'
+                "Stored event repository class `$storedEventRepository` does not implement `" . StoredEventRepository::class . '`'
             );
         }
 

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -266,7 +266,8 @@ class Projectionist
     public function replay(
         Collection $projectors,
         int $startingFromEventId = 0,
-        callable $onEventReplayed = null
+        callable $onEventReplayed = null,
+        string $storedEventRepositoryClass = null
     ): void {
         $projectors = new EventHandlerCollection($projectors);
 
@@ -284,7 +285,7 @@ class Projectionist
 
         $projectors->call('onStartingEventReplay');
 
-        app(StoredEventRepository::class)
+        app($storedEventRepositoryClass ?? StoredEventRepository::class)
             ->retrieveAllStartingFrom($startingFromEventId)
             ->each(function (StoredEvent $storedEvent) use ($projectors, $onEventReplayed) {
                 $this->applyStoredEventToProjectors(


### PR DESCRIPTION
I wanted to use the --stored-event-model option but I noticed that it wasn't used anymore in the replay command. It also made more sense to specify a stored event repository as option in the command instead of a stored event model. Added this because sometimes you would like to replay only the events from a specific store.