### PR TITLE
Update documentation to match the code

### DIFF
--- a/docs/using-projectors/creating-and-configuring-projectors.md
+++ b/docs/using-projectors/creating-and-configuring-projectors.md
@@ -15,7 +15,7 @@ php artisan make:projector AccountBalanceProjector
 
 ## Registering projectors
 
-By default, the package will automatically find an register all projectors found in your application.
+By default, the package will automatically find and register all projectors found in your application.
 
 Alternatively, you can manually register projectors in the `projectors` key of the `event-sourcings` config file.
 

--- a/docs/using-projectors/writing-your-first-projector.md
+++ b/docs/using-projectors/writing-your-first-projector.md
@@ -94,7 +94,7 @@ class Account extends Model
 
 ## Defining events
 
-Instead of creating, updating and deleting accounts, we're simply firing off events. All these events should implement `\Spatie\EventSourcing\ShouldBeStored`. This is an empty interface that signifies to our package that the event should be stored.
+Instead of creating, updating and deleting accounts, we're simply firing off events. All these events should extend `\Spatie\EventSourcing\StoredEvents\ShouldBeStored`. This abstract class signifies to our package that the event should be stored.
 
 Let's take a look at all events used in the `Account` model.
 


### PR DESCRIPTION
Updates a presumably outdated reference to an empty interface that doesn't exist, so that it now matches the code samples immediately below :smiley: