### PR TITLE
Fix broken link to CONTRIBUTING.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Please see [CHANGELOG](CHANGELOG.md) for more information what has changed recen
 
 ## Contributing
 
-Please see [CONTRIBUTING](CONTRIBUTING.md) for details.
+Please see [CONTRIBUTING](.github/CONTRIBUTING.md) for details.
 
 ## Security
 


### PR DESCRIPTION
Hi,

I noticed the link in the README to your `CONTRIBUTING.md` file is broken as it's been moved to the `.github` folder.

Thanks!