### PR TITLE
Model and Collection normalization

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -89,6 +89,19 @@ return [
      * should implement Spatie\EventSourcing\EventSerializers\EventSerializer.
      */
     'event_serializer' => Spatie\EventSourcing\EventSerializers\JsonEventSerializer::class,
+    
+    /*
+     * These classes normalize and restore your events when they're serialized. They allow
+     * you to efficiently store PHP objects like Carbon instances, Eloquent models, and
+     * Collections. If you need to store other complex data, you can add your own normalizers
+     * to the chain. See https://symfony.com/doc/current/components/serializer.html#normalizers
+     */
+    'event_normalizers' => [
+        Spatie\EventSourcing\Support\CarbonNormalizer::class,
+        Spatie\EventSourcing\Support\ModelIdentifierNormalizer::class,
+        Symfony\Component\Serializer\Normalizer\DateTimeNormalizer::class,
+        Symfony\Component\Serializer\Normalizer\ObjectNormalizer::class,
+    ],
 
     /*
      * When replaying events, potentially a lot of events will have to be retrieved.

--- a/docs/advanced-usage/preparing-events.md
+++ b/docs/advanced-usage/preparing-events.md
@@ -37,8 +37,6 @@ class MoneyAdded extends ShouldBeStored
 
 Whenever an event that implements `ShouldBeStored` is fired it will be serialized and written in the `stored_events` table. Immediately after that, the event will be passed to all projectors and reactors.
 
-If your event has an eloquent model, it should also use the `Illuminate\Queue\SerializesModels` trait so we are able to serialize these models correctly.
-
 ## Specifying a queue
 
 When a `StoredEvent` is created, we'll dispatch a job on the queue defined in the `queue` key of the `event-sourcing` config file. Queued projectors and reactors will get called when the job is executed on the queue.

--- a/src/EventSerializers/JsonEventSerializer.php
+++ b/src/EventSerializers/JsonEventSerializer.php
@@ -25,7 +25,7 @@ class JsonEventSerializer implements EventSerializer
     {
         $encoders = [new JsonEncoder()];
         $normalizers = array_map(
-            fn ($className) => app($className),
+            fn ($className) => new $className,
             config('event-sourcing.event_normalizers', self::DEFAULT_NORMALIZERS)
         );
 

--- a/src/EventSerializers/JsonEventSerializer.php
+++ b/src/EventSerializers/JsonEventSerializer.php
@@ -12,13 +12,6 @@ use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 
 class JsonEventSerializer implements EventSerializer
 {
-    private const DEFAULT_NORMALIZERS = [
-        CarbonNormalizer::class,
-        ModelIdentifierNormalizer::class,
-        DateTimeNormalizer::class,
-        ObjectNormalizer::class,
-    ];
-    
     private SymfonySerializer $serializer;
 
     public function __construct()
@@ -26,7 +19,7 @@ class JsonEventSerializer implements EventSerializer
         $encoders = [new JsonEncoder()];
         $normalizers = array_map(
             fn ($className) => new $className,
-            config('event-sourcing.event_normalizers', self::DEFAULT_NORMALIZERS)
+            config('event-sourcing.event_normalizers')
         );
 
         $this->serializer = new SymfonySerializer($normalizers, $encoders);

--- a/src/EventSerializers/JsonEventSerializer.php
+++ b/src/EventSerializers/JsonEventSerializer.php
@@ -12,21 +12,21 @@ use Symfony\Component\Serializer\Serializer as SymfonySerializer;
 
 class JsonEventSerializer implements EventSerializer
 {
-	private const DEFAULT_NORMALIZERS = [
-		CarbonNormalizer::class,
-		ModelIdentifierNormalizer::class,
-		DateTimeNormalizer::class,
-		ObjectNormalizer::class,
-	];
-	
+    private const DEFAULT_NORMALIZERS = [
+        CarbonNormalizer::class,
+        ModelIdentifierNormalizer::class,
+        DateTimeNormalizer::class,
+        ObjectNormalizer::class,
+    ];
+    
     private SymfonySerializer $serializer;
 
     public function __construct()
     {
         $encoders = [new JsonEncoder()];
         
-        $normalizerClassNames = config('event-sourcing.event_normalizers', static::DEFAULT_NORMALIZERS);
-        $normalizers = array_map(fn($className) => app($className), $normalizerClassNames);
+        $normalizerClassNames = config('event-sourcing.event_normalizers', self::DEFAULT_NORMALIZERS);
+        $normalizers = array_map(fn ($className) => app($className), $normalizerClassNames);
 
         $this->serializer = new SymfonySerializer($normalizers, $encoders);
     }

--- a/src/EventSerializers/JsonEventSerializer.php
+++ b/src/EventSerializers/JsonEventSerializer.php
@@ -24,9 +24,10 @@ class JsonEventSerializer implements EventSerializer
     public function __construct()
     {
         $encoders = [new JsonEncoder()];
-        
-        $normalizerClassNames = config('event-sourcing.event_normalizers', self::DEFAULT_NORMALIZERS);
-        $normalizers = array_map(fn ($className) => app($className), $normalizerClassNames);
+        $normalizers = array_map(
+            fn ($className) => app($className),
+            config('event-sourcing.event_normalizers', self::DEFAULT_NORMALIZERS)
+        );
 
         $this->serializer = new SymfonySerializer($normalizers, $encoders);
     }

--- a/src/Support/ModelIdentifierNormalizer.php
+++ b/src/Support/ModelIdentifierNormalizer.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Spatie\EventSourcing\Support;
+
+use Illuminate\Contracts\Database\ModelIdentifier;
+use Illuminate\Contracts\Queue\QueueableCollection;
+use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
+use InvalidArgumentException;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+
+class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    use SerializesAndRestoresModelIdentifiers;
+    
+    /**
+     * @inheritdoc
+     */
+    public function normalize($object, string $format = null, array $context = [])
+    {
+        if (! $this->supportsNormalization($object)) {
+            throw new InvalidArgumentException('Cannot serialize an object that is not a QueueableEntity or QueueableCollection in ModelIdentifierNormalizer.');
+        }
+    
+        return $this->getSerializedPropertyValue($object);
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function supportsNormalization($data, string $format = null)
+    {
+        return ($data instanceof QueueableEntity || $data instanceof QueueableCollection);
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function denormalize($data, $class, string $format = null, array $context = [])
+    {
+        $identifier = $data instanceof ModelIdentifier
+	        ? $data
+	        : new ModelIdentifier($data['class'], $data['id'], $data['relations'], $data['connection']);
+        
+        return $this->getRestoredPropertyValue($identifier);
+    }
+    
+    /**
+     * @inheritdoc
+     */
+    public function supportsDenormalization($data, $type, string $format = null)
+    {
+        return $this->normalizedDataIsModelIdentifier($data)
+            && $this->isNormalizedToModelIdentifier($type);
+    }
+    
+    protected function normalizedDataIsModelIdentifier($data): bool
+    {
+        return $data instanceof ModelIdentifier
+            || isset($data['class'], $data['id'], $data['relations'], $data['connection']);
+    }
+    
+    protected function isNormalizedToModelIdentifier($class): bool
+    {
+        return is_a($class, QueueableEntity::class, true)
+            || is_a($class, QueueableCollection::class, true);
+    }
+}

--- a/tests/TestClasses/Events/MoneyAddedEvent.php
+++ b/tests/TestClasses/Events/MoneyAddedEvent.php
@@ -2,15 +2,12 @@
 
 namespace Spatie\EventSourcing\Tests\TestClasses\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
 
 class MoneyAddedEvent extends ShouldBeStored
 {
-    use SerializesModels;
-
-    public object $account;
+    public Account $account;
 
     public int $amount;
 

--- a/tests/TestClasses/Events/MoneyAddedEventWithQueueOverride.php
+++ b/tests/TestClasses/Events/MoneyAddedEventWithQueueOverride.php
@@ -2,15 +2,12 @@
 
 namespace Spatie\EventSourcing\Tests\TestClasses\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
 
 class MoneyAddedEventWithQueueOverride extends ShouldBeStored
 {
-    use SerializesModels;
-
-    public object $account;
+    public Account $account;
 
     public int $amount;
 

--- a/tests/TestClasses/Events/MoneySubtractedEvent.php
+++ b/tests/TestClasses/Events/MoneySubtractedEvent.php
@@ -2,15 +2,12 @@
 
 namespace Spatie\EventSourcing\Tests\TestClasses\Events;
 
-use Illuminate\Queue\SerializesModels;
 use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
 
 class MoneySubtractedEvent extends ShouldBeStored
 {
-    use SerializesModels;
-
-    public object $account;
+    public Account $account;
 
     public int $amount;
 


### PR DESCRIPTION
The current implementation that uses `SerializesModels` does not work with collections of models, and also fails if you type hint your StoredEvent's properties with the model class or `Collection`. This solves that by introducing a new `ModelIdentifierNormalizer` instead.

Under the hood, it defers to the same logic that `SerializesModels` uses, but it does it as part of the serialization/normalization chain.

I've also made the normalization chain configurable, so that it's not necessary to re-implement the serializer just to add custom normalizers. I'm happy to remove that customization if you feel it's too much, but I do think it's worthwhile.

This could be considered a breaking change, but I don't think it is—if `SerializesModels` exists on the event, it will still work correctly.