### PR TITLE
Added loadUuid function to avoid static retrieve function

### DIFF
--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -40,6 +40,16 @@ $myAggregate = new MyAggregate();
 $myAggregate->loadUuid($uuid);
 ```
 
+The `load` method is handy when injecting aggretate roots in constructors or classes where method injection is supported.
+
+```php
+public function handle(MyAggregate $aggregate) {
+    $aggregate->load($uuid);
+    
+    // ...
+}
+```
+
 This will cause all events with the given `uuid` to be retrieved and fed to the aggregate. For example, an event `MoneyAdded` will be passed to the `applyMoneyAdded` method on the aggregate if such a method exists.
 
 

--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -33,8 +33,15 @@ An aggregate can be retrieved like this:
 ```php
 MyAggregate::retrieve($uuid)
 ```
+If you don't want to use the static retrieve method, you can also retrieve an aggregate on an initialized AggregateRoot like this: 
+
+```php
+$myAggregate = new MyAggregate();
+$myAggregate->loadUuid($uuid);
+```
 
 This will cause all events with the given `uuid` to be retrieved and fed to the aggregate. For example, an event `MoneyAdded` will be passed to the `applyMoneyAdded` method on the aggregate if such a method exists.
+
 
 ## Recording events
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -43,6 +43,13 @@ abstract class AggregateRoot
         return $aggregateRoot->reconstituteFromEvents();
     }
 
+    public function loadUuid(string $uuid): self
+    {
+        $this->uuid = $uuid;
+
+        return $this->reconstituteFromEvents();
+    }
+
     public function uuid(): string
     {
         return $this->uuid;

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -379,4 +379,31 @@ class AggregateRootTest extends TestCase
             return true;
         });
     }
+
+    /** @test */
+    public function it_can_load_the_uuid()
+    {
+        $aggregateRoot = (new AccountAggregateRoot())->loadUuid($this->aggregateUuid);
+
+        $this->assertEquals($this->aggregateUuid, $aggregateRoot->uuid());
+    }
+
+    /** @test */
+    public function it_persists_when_uuid_is_loaded()
+    {
+        (new AccountAggregateRoot())
+            ->loadUuid($this->aggregateUuid)
+            ->addMoney(100)
+            ->persist();
+
+        $storedEvents = EloquentStoredEvent::get();
+        $this->assertCount(1, $storedEvents);
+
+        $storedEvent = $storedEvents->first();
+        $this->assertEquals($this->aggregateUuid, $storedEvent->aggregate_uuid);
+
+        $event = $storedEvent->event;
+        $this->assertInstanceOf(MoneyAdded::class, $event);
+        $this->assertEquals(100, $event->amount);
+    }
 }


### PR DESCRIPTION
This non-breaking PR will add a non-static method to load in the UUID so that the AggregateRoot can be injected. 