### PR TITLE
Re-use existing instance of ShouldBeStored when possible

### DIFF
--- a/src/StoredEvents/Models/EloquentStoredEvent.php
+++ b/src/StoredEvents/Models/EloquentStoredEvent.php
@@ -20,6 +20,8 @@ class EloquentStoredEvent extends Model
         'event_properties' => 'array',
         'meta_data' => 'array',
     ];
+    
+    protected ?ShouldBeStored $originalEvent = null;
 
     public function toStoredEvent(): StoredEvent
     {
@@ -31,12 +33,19 @@ class EloquentStoredEvent extends Model
             'event_class' => $this->event_class,
             'meta_data' => $this->meta_data,
             'created_at' => $this->created_at,
-        ]);
+        ], $this->originalEvent);
+    }
+    
+    public function setOriginalEvent(ShouldBeStored $event): self
+    {
+        $this->originalEvent = $event;
+        
+        return $this;
     }
 
     public function getEventAttribute(): ?ShouldBeStored
     {
-        return $this->toStoredEvent()->event;
+        return $this->originalEvent ??= $this->toStoredEvent()->event;
     }
 
     public function getMetaDataAttribute(): SchemalessAttributes

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -71,11 +71,13 @@ class EloquentStoredEventRepository implements StoredEventRepository
         /** @var EloquentStoredEvent $eloquentStoredEvent */
         $eloquentStoredEvent = new $this->storedEventModel();
 
+        $eloquentStoredEvent->setOriginalEvent($event);
+        
         $eloquentStoredEvent->setRawAttributes([
             'event_properties' => app(EventSerializer::class)->serialize(clone $event),
             'aggregate_uuid' => $uuid,
             'aggregate_version' => $aggregateVersion,
-            'event_class' => self::getEventClass(get_class($event)),
+            'event_class' => $this->getEventClass(get_class($event)),
             'meta_data' => json_encode($event->metaData()),
             'created_at' => Carbon::now(),
         ]);
@@ -90,7 +92,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         $storedEvents = [];
 
         foreach ($events as $event) {
-            $storedEvents[] = self::persist($event, $uuid, $aggregateVersion);
+            $storedEvents[] = $this->persist($event, $uuid, $aggregateVersion);
         }
 
         return new LazyCollection($storedEvents);

--- a/tests/EloquentStoredEventRepositoryTest.php
+++ b/tests/EloquentStoredEventRepositoryTest.php
@@ -4,6 +4,7 @@ namespace Spatie\EventSourcing\Tests;
 
 use Spatie\EventSourcing\StoredEvents\Repositories\EloquentStoredEventRepository;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
 
 class EloquentStoredEventRepositoryTest extends TestCase
 {
@@ -27,5 +28,16 @@ class EloquentStoredEventRepositoryTest extends TestCase
         $anotherAggregateRoot->addMoney(100)->persist();
         $this->assertEquals(1, $eloquentStoredEventRepository->getLatestAggregateVersion('uuid-2'));
         $this->assertEquals(2, $eloquentStoredEventRepository->getLatestAggregateVersion('uuid-1'));
+    }
+    
+    /** @test */
+    public function it_sets_the_original_event_on_persist()
+    {
+        $eloquentStoredEventRepository = app(EloquentStoredEventRepository::class);
+        
+        $originalEvent = new MoneyAdded(100);
+        $storedEvent = $eloquentStoredEventRepository->persist($originalEvent, 'uuid-1', 1);
+        
+        $this->assertSame($originalEvent, $storedEvent->event);
     }
 }

--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -2,11 +2,14 @@
 
 namespace Spatie\EventSourcing\Tests\Models;
 
+use Carbon\Carbon;
+use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\Exceptions\InvalidStoredEvent;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
 use Spatie\EventSourcing\StoredEvents\StoredEvent;
 use Spatie\EventSourcing\Tests\TestCase;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\BalanceProjector;
@@ -132,6 +135,18 @@ class StoredEventTest extends TestCase
         $storedEvent = $eloquentEvent->toStoredEvent();
 
         $this->assertEquals(0, $storedEvent->aggregate_version);
+    }
+    
+    /** @test */
+    public function it_uses_the_original_event_if_set()
+    {
+        $originalEvent = new MoneyAdded(100);
+        
+        $eloquentStoredEvent = new EloquentStoredEvent();
+        
+        $eloquentStoredEvent->setOriginalEvent($originalEvent);
+        
+        $this->assertSame($originalEvent, $eloquentStoredEvent->event);
     }
 
     public function fireEvents(int $number = 1, string $className = MoneyAddedEvent::class)


### PR DESCRIPTION
Currently, when you call `EloquentStoredEventRepository::persist()`, this persists the event to the database and then immediately returns the deserialized version of that event. When the attributes on the event are all basic data types like `string` and `int`, the performance hit associated with serializing and deserializing is negligible. When one or more attributes on the event are eloquent models, this can result in an N+1 issue.

This PR introduces the concept of the "original event" to `StoredEvent` and `EloquentStoredEvent`. If the original event is provided and/or present, these models can re-use it. If not, the models can instantiate it from the serialized data.