### PR TITLE
Allow for snake_case parameters in handle methods

### DIFF
--- a/src/EventHandlers/HandlesEvents.php
+++ b/src/EventHandlers/HandlesEvents.php
@@ -27,7 +27,9 @@ trait HandlesEvents
         $parameters = [
             'event' => $storedEvent->event,
             'storedEvent' => $storedEvent,
+            'stored_event' => $storedEvent,
             'aggregateUuid' => $storedEvent->aggregate_uuid,
+            'aggregate_uuid' => $storedEvent->aggregate_uuid,
         ];
 
         if (class_exists($handlerClassOrMethod)) {


### PR DESCRIPTION
This may be controversial, but I'll give it a shot :)

Our coding standard requires that variables be `$snake_cased` (like the argument for using a light editor theme, [there's evidence that it takes about 20% longer to read `$camelCase` variables](https://whatheco.de/2013/02/16/camelcase-vs-underscores-revisited/)).

This PR just adds `stored_event` and `aggregate_uuid` to the list of parameters available to event handler method injection. This gives the consuming code the option to use either style as they see fit!