### PR TITLE
Add beforeApply to AggregateRoot

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -196,6 +196,8 @@ abstract class AggregateRoot
 
     private function apply(ShouldBeStored $event): void
     {
+        $this->beforeApply($event);
+
         $classBaseName = class_basename($event);
 
         $camelCasedBaseName = ucfirst(Str::camel($classBaseName));
@@ -213,6 +215,10 @@ abstract class AggregateRoot
         $this->appliedEvents[] = $event;
 
         $this->aggregateVersion++;
+    }
+
+    protected function beforeApply(ShouldBeStored $event): void
+    {
     }
 
     public static function fake(string $uuid = null): FakeAggregateRoot

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -12,6 +12,7 @@ use Spatie\EventSourcing\Snapshots\EloquentSnapshot;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootThatAllowsConcurrency;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithBeforeApply;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithFailingPersist;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithStoredEventRepositorySpecified;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Mailable\MoneyAddedMailable;
@@ -405,5 +406,15 @@ class AggregateRootTest extends TestCase
         $event = $storedEvent->event;
         $this->assertInstanceOf(MoneyAdded::class, $event);
         $this->assertEquals(100, $event->amount);
+    }
+
+    /** @test */
+    public function it_runs_before_apply_before_it_applies_a_method()
+    {
+        $aggregateRoot = new AccountAggregateRootWithBeforeApply();
+
+        $aggregateRoot->addMoney(100);
+
+        $this->assertTrue($aggregateRoot->beforeApplyWasCalled);
     }
 }

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRootWithBeforeApply.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRootWithBeforeApply.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class AccountAggregateRootWithBeforeApply extends AccountAggregateRoot
+{
+    public bool $beforeApplyWasCalled = false;
+
+    protected function beforeApply(ShouldBeStored $event): void
+    {
+        $this->beforeApplyWasCalled = true;
+    }
+}


### PR DESCRIPTION
This PR adds a `beforeApply` method to the `AggregateRoot` that can be overridden to _always_ do something before applying an event.

We often come across a situation where the aggregate root needs to be kickstarted with a `start` or `initialize` event of sort, and every other method needs to ensure that the aggregate root has been initialized.

```php
class PaymentAggregateRoot
{
    public int $due;

    public int $paid = 0;

    public function start(int $due): void
    {
    	$this->recordThat(new PaymentStartedEvent($due));
    }

    public function pay(int $amount): void
    {
    	if (! isset($this->due)) {
    		throw new Exception("A payment must always have a due amount");
    	}

    	$this->recordThat(new PaidEvent($amount));
    }
}
```

With `beforeApply`, we can move that rule to always be called, and not worry about it anymore.

```php
class PaymentAggregateRoot
{
    public int $due;

    public int $paid = 0;

    public function start(int $due): void
    {
    	$this->recordThat(new PaymentStartedEvent($due));
    }

    public function pay(int $amount): void
    {
    	$this->recordThat(new PaidEvent($amount));
    }

    public function beforeApply(ShouldBeStored $event): void
    {
        if ($event instanceof PaymentStartedEvent) {
            return;
        }

    	if (! isset($this->due)) {
    		throw new Exception("A payment must always have a due amount");
    	}
    }
}
```

Alternatively, we could make `apply` protected instead of private, so you could override it and call `parent::apply()`. I actually prefer this approach, but not sure if it has other implications. And can we do that non-breaking?

```php
class PaymentAggregateRoot
{
    public int $due;

    public int $paid = 0;

    public function start(int $due): void
    {
    	$this->recordThat(new PaymentStartedEvent($due));
    }

    public function pay(int $amount): void
    {
    	$this->recordThat(new PaidEvent($amount));
    }

    protected function apply(ShouldBeStored $event): void
    {
    	if ($event instanceof PaymentStarted) {
    		parent::apply($event);

    		return;
    	}

    	if (! isset($this->due)) {
    		throw new Exception("A payment must always have a due amount");
    	}

    	parent::apply($event);
    }
}
```

Ping @brendt for a second opinion.