### PR TITLE
Add persistWithTransaction method to aggregate root

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -85,6 +85,18 @@ abstract class AggregateRoot
         return $this;
     }
 
+    /**
+     * @return static
+     */
+    public function persistWithTransaction()
+    {
+        DB::transaction(function () {
+            $this->persist();
+        });
+
+        return $this;
+    }
+
     protected function persistWithoutApplyingToEventHandlers(): LazyCollection
     {
         $this->ensureNoOtherEventsHaveBeenPersisted();

--- a/tests/TestClasses/AggregateRoots/Projectors/ProjectorThatThrowsAnException.php
+++ b/tests/TestClasses/AggregateRoots/Projectors/ProjectorThatThrowsAnException.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Projectors;
+
+use Exception;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+
+class ProjectorThatThrowsAnException extends AccountProjector
+{
+    public function onMoneyAdded(MoneyAdded $event, string $aggregateUuid)
+    {
+        throw new Exception('Computer says no.');
+    }
+}


### PR DESCRIPTION
Sometimes I might want to ensure my projectors and reactors succeed before persisting my event. 

In this case I would use `persistWithTransaction` instead of `persist` (totally opt-in)

This is a little bit against "pure" event sourcing, but I think it's an improvement of life since if something goes wrong in a projector, it might indicate that something was missed in the aggregate root in terms of validation. 

A simple use case is a unique requirement on the database - if the database throws a unique error - we probably don't want to commit to an event to our event store that violates a unique business rule? Or should the aggregate root, be looking into a projection table to check uniqueness before recording an event? 

Note: Any projectors / reactors that are marked as `ShouldQueue` won't be affected due to their async nature (which I think is a good thing as an examle - a SendWelcomeMail reactor shouldn't stop someone from signing up)