### PR TITLE
Improve assertions

### DIFF
--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -98,7 +98,7 @@ class StoredEventTest extends TestCase
             'created_at' => $eloquentEvent->created_at,
         ]);
 
-        $this->assertEquals(MoneyAddedEvent::class, get_class($storedEvent->event));
+        $this->assertInstanceOf(MoneyAddedEvent::class, $storedEvent->event);
     }
 
     /** @test * */
@@ -120,7 +120,7 @@ class StoredEventTest extends TestCase
             'created_at' => $eloquentEvent->created_at,
         ]);
 
-        $this->assertEquals(MoneyAddedEvent::class, get_class($storedEvent->event));
+        $this->assertInstanceOf(MoneyAddedEvent::class, $storedEvent->event);
     }
 
     /** @test **/
@@ -132,7 +132,7 @@ class StoredEventTest extends TestCase
 
         $storedEvent = $eloquentEvent->toStoredEvent();
 
-        $this->assertEquals(0, $storedEvent->aggregate_version);
+        $this->assertSame('0', $storedEvent->aggregate_version);
     }
     
     /** @test */

--- a/tests/ProjectionistTest.php
+++ b/tests/ProjectionistTest.php
@@ -173,7 +173,7 @@ class ProjectionistTest extends TestCase
         Projectionist::withoutEventHandlers([MoneyAddedCountProjector::class, BrokeReactor::class]);
 
         $this->assertCount(1, Projectionist::getProjectors());
-        $this->assertEquals(BalanceProjector::class, get_class(Projectionist::getProjectors()->first()));
+        $this->assertInstanceOf(BalanceProjector::class, Projectionist::getProjectors()->first());
         $this->assertCount(0, Projectionist::getReactors());
 
         Projectionist::withoutEventHandler(BalanceProjector::class);


### PR DESCRIPTION
# Changed log

- Using the `aasertSame` to assert expected is `0` strictly.
- Using the `assertInstanceOf` to assert expected is same as result instance.