### PR TITLE
Allow retrieving an aggregate at a specific version

### DIFF
--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -55,7 +55,7 @@ This will cause all events with the given `uuid` to be retrieved and fed to the 
 The aggregate also allows you to travel back in time, by passing a version number to retrieve. To check our account balance in the past:
 
 ```php
-$account = MyAggregate::retrieve($uuid, 3);
+$account = AccountAggregate::retrieve($uuid, 3);
 return $account->balance;
 ```
 

--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -40,7 +40,7 @@ $myAggregate = new MyAggregate();
 $myAggregate->loadUuid($uuid);
 ```
 
-The `load` method is handy when injecting aggretate roots in constructors or classes where method injection is supported.
+The `load` method is handy when injecting aggregate roots in constructors or classes where method injection is supported.
 
 ```php
 public function handle(MyAggregate $aggregate) {
@@ -52,6 +52,12 @@ public function handle(MyAggregate $aggregate) {
 
 This will cause all events with the given `uuid` to be retrieved and fed to the aggregate. For example, an event `MoneyAdded` will be passed to the `applyMoneyAdded` method on the aggregate if such a method exists.
 
+The aggregate also allows you to travel back in time, by passing a version number to retrieve. To check our account balance in the past:
+
+```php
+$account = MyAggregate::retrieve($uuid, 3);
+return $account->balance;
+```
 
 ## Recording events
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -167,7 +167,7 @@ abstract class AggregateRoot
         }
 
         $storedEventRepository->retrieveAllAfterVersion($this->aggregateVersion, $this->uuid)
-            ->takeWhile(function (StoredEvent $storedEvent) use ($maxAggregateVersion) {
+            ->filter(function (StoredEvent $storedEvent) use ($maxAggregateVersion) {
                 return ! $maxAggregateVersion || $storedEvent->aggregate_version <= $maxAggregateVersion;
             })
             ->each(function (StoredEvent $storedEvent) {

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -34,16 +34,7 @@ abstract class AggregateRoot
      *
      * @return static
      */
-    public static function retrieve(string $uuid)
-    {
-        $aggregateRoot = app(static::class);
-
-        $aggregateRoot->uuid = $uuid;
-
-        return $aggregateRoot->reconstituteFromEvents();
-    }
-
-    public static function retrieveAtVersion(string $uuid, int $aggregateVersion)
+    public static function retrieve(string $uuid, int $aggregateVersion = null)
     {
         $aggregateRoot = app(static::class);
 
@@ -52,11 +43,11 @@ abstract class AggregateRoot
         return $aggregateRoot->reconstituteFromEvents($aggregateVersion);
     }
 
-    public function loadUuid(string $uuid): self
+    public function loadUuid(string $uuid, int $aggregateVersion = null): self
     {
         $this->uuid = $uuid;
 
-        return $this->reconstituteFromEvents();
+        return $this->reconstituteFromEvents($aggregateVersion);
     }
 
     public function uuid(): string

--- a/src/Snapshots/EloquentSnapshotRepository.php
+++ b/src/Snapshots/EloquentSnapshotRepository.php
@@ -17,10 +17,14 @@ class EloquentSnapshotRepository implements SnapshotRepository
         }
     }
 
-    public function retrieve(string $aggregateUuid): ?Snapshot
+    public function retrieve(string $aggregateUuid, int $maxAggregateVersion = null): ?Snapshot
     {
         /** @var \Illuminate\Database\Query\Builder $query */
         $query = $this->snapshotModel::query();
+
+        if ($maxAggregateVersion) {
+            $query->where('aggregate_version', '<=', $maxAggregateVersion);
+        }
 
         if ($snapshot = $query->latest()->uuid($aggregateUuid)->first()) {
             return $snapshot->toSnapshot();

--- a/src/Snapshots/SnapshotRepository.php
+++ b/src/Snapshots/SnapshotRepository.php
@@ -4,7 +4,7 @@ namespace Spatie\EventSourcing\Snapshots;
 
 interface SnapshotRepository
 {
-    public function retrieve(string $aggregateUuid): ?Snapshot;
+    public function retrieve(string $aggregateUuid, int $maxAggregateVersion = null): ?Snapshot;
 
     public function persist(Snapshot $snapshot): Snapshot;
 }

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -158,7 +158,7 @@ class AggregateRootTest extends TestCase
             ->addMoney(100)->persist() // v2
             ->addMoney(100)->persist(); // v3
 
-        $aggregateRoot = AccountAggregateRoot::retrieveAtVersion($this->aggregateUuid, 2);
+        $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid, 2);
 
         $this->assertEquals(200, $aggregateRoot->balance);
     }
@@ -253,7 +253,7 @@ public function events_saved_after_the_snapshot_are_not_reconstituted_if_retriev
     $aggregateRoot->snapshot();
     $aggregateRoot->addMoney(100)->persist(); // v4
 
-    $aggregateRootRetrieved = AccountAggregateRoot::retrieveAtVersion($this->aggregateUuid, 2);
+    $aggregateRootRetrieved = AccountAggregateRoot::retrieve($this->aggregateUuid, 2);
 
     $this->assertEquals(2, $aggregateRootRetrieved->aggregateVersion);
     $this->assertEquals(200, $aggregateRootRetrieved->balance);


### PR DESCRIPTION
I ran into a situation where I needed to retrieve an aggregate for a specific state in the past. This PR adds an optional 2nd argument to the Aggregate Root, so it's possible to get a previous state of an aggregate, instead of just the latest. 

A concrete use-case is when trying to compare a previous state to the latest state, exactly like this PR 🥁 

I also believe this is another solid use case to use aggregates, in addition to the other benefit of making decisions based on past events. 

Here's how it would work with this PR in place:

```php
$account = AccountAggregate::retrieve($uuid, 3);
return $account->balance;
```

Since this is an optional argument, there should be no breaking changes. I also added the argument to `AggregateRoot::loadUuid`, for consistency.

Let me know what you think and if the PR needs any tweaks.

Co-Author: @lukecurtis93
Credit: Quality checked against https://github.com/spatie/simple-excel/pull/43 due to https://twitter.com/freekmurze/status/1337047675611582464