### PR TITLE
Allow custom path as a base path

### DIFF
--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -114,7 +114,7 @@ class EventSourcingServiceProvider extends ServiceProvider
 
         (new DiscoverEventHandlers())
             ->within(config('event-sourcing.auto_discover_projectors_and_reactors'))
-            ->useBasePath(base_path(config('event-sourcing.base_path')))
+            ->useBasePath(config('event-sourcing.base_path', base_path()))
             ->ignoringFiles(Composer::getAutoloadedFiles(base_path('composer.json')))
             ->addToProjectionist($projectionist);
     }

--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -114,7 +114,7 @@ class EventSourcingServiceProvider extends ServiceProvider
 
         (new DiscoverEventHandlers())
             ->within(config('event-sourcing.auto_discover_projectors_and_reactors'))
-            ->useBasePath(base_path())
+            ->useBasePath(base_path(config('event-sourcing.base_path')))
             ->ignoringFiles(Composer::getAutoloadedFiles(base_path('composer.json')))
             ->addToProjectionist($projectionist);
     }

--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -114,7 +114,7 @@ class EventSourcingServiceProvider extends ServiceProvider
 
         (new DiscoverEventHandlers())
             ->within(config('event-sourcing.auto_discover_projectors_and_reactors'))
-            ->useBasePath(config('event-sourcing.base_path', base_path()))
+            ->useBasePath(config('event-sourcing.auto_discover_base_path', base_path()))
             ->ignoringFiles(Composer::getAutoloadedFiles(base_path('composer.json')))
             ->addToProjectionist($projectionist);
     }


### PR DESCRIPTION
When applying the custom directory structure as suggested by the "Laravel Beyond Crud" book, the event discovery fails as it uses the base path to guess the class names from the file names.

https://github.com/spatie/laravel-event-sourcing/blob/05d0aa072ac6385aebda0d84519a8aa389fe2813/src/Support/DiscoverEventHandlers.php#L72-L83

So a Projector placed at `./src/App/Projectors/UsersProjector.php` is guessed as this class `Src\App\Projectors\UsersProjector`, which does not exist.

By allowing a user to specify a custom config key one could add this config key:

~~~php
'auto_discover_base_path' => base_path('src'),
~~~

And have the `src` part ignored.

As it is seems to be an edge case, I didn't add a config key on the config stub.

If you prefer me to do so, please let know and I will update the PR.

More reasoning here: https://github.com/spatie/laravel-beyond-crud-demo/issues/7#issuecomment-792965120 (private repo)

**EDIT** I pushed more commits to allow for a more descriptive config key