### PR TITLE
Add config key to stub

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -11,6 +11,12 @@ return [
     ],
 
     /*
+     * This directory will be used as the base path when scanning
+     * for projectors and reactors.
+     */
+    'auto_discover_base_path' => base_path(),
+
+    /*
      * Projectors are classes that build up projections. You can create them by performing
      * `php artisan event-sourcing:create-projector`. When not using auto-discovery,
      * Projectors can be registered in this array or a service provider.


### PR DESCRIPTION
Follow up of PR #202 

This PR adds a config key to the config stub to make it easier to specify a base path when auto-scanning for projectors and reactors.