### PR TITLE
Race condition fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to `laravel-event-sourcing` will be documented in this file:
 
+## 4.10.0 - ?
+
+- Fix for race condition in aggregate roots (#170), you will need to run a migration to be able to use it:
+
+```php
+public function up()
+{
+    Schema::table('stored_events', function (Blueprint $table) {
+        $table->unique(['aggregate_uuid', 'aggregate_version']);
+    });
+}
+```
+
 ## 4.9.0 - 2021-03-10
 
 - Make base path configurable (#202)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to `laravel-event-sourcing` will be documented in this file:
 
 ## 4.10.0 - ?
 
+- Deprecate `AggregateRoot::$allowConcurrency`
 - Fix for race condition in aggregate roots (#170), you will need to run a migration to be able to use it:
 
 ```php
@@ -14,6 +15,8 @@ public function up()
     });
 }
 ```
+
+**Note**: if you run this migration, all aggregate roots using `$allowConcurrency` will not work any more.
 
 ## 4.9.0 - 2021-03-10
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -27,6 +27,10 @@ abstract class AggregateRoot
 
     protected int $aggregateVersionAfterReconstitution = 0;
 
+    /**
+     * @var bool
+     * @deprecated Will be removed in v5
+     */
     protected static bool $allowConcurrency = false;
 
     /**

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -68,6 +68,8 @@ abstract class AggregateRoot
 
         $this->apply($domainEvent);
 
+        $domainEvent->setAggregateRootVersion($this->aggregateVersion);
+
         return $this;
     }
 
@@ -159,6 +161,7 @@ abstract class AggregateRoot
     protected function reconstituteFromEvents(): self
     {
         $storedEventRepository = $this->getStoredEventRepository();
+
         $snapshot = $this->getSnapshotRepository()->retrieve($this->uuid);
 
         if ($snapshot) {

--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -126,6 +126,7 @@ class FakeAggregateRoot
             $metaData = $event->metaData();
 
             unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
+            unset($metaData[MetaData::AGGREGATE_ROOT_VERSION]);
 
             return $event->setMetaData($metaData);
         }, $this->aggregateRoot->getAppliedEvents());
@@ -164,6 +165,7 @@ class FakeAggregateRoot
             $metaData = $event->metaData();
 
             unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
+            unset($metaData[MetaData::AGGREGATE_ROOT_VERSION]);
 
             return $event->setMetaData($metaData);
         }, $this->aggregateRoot->getRecordedEvents());

--- a/src/Enums/MetaData.php
+++ b/src/Enums/MetaData.php
@@ -5,4 +5,5 @@ namespace Spatie\EventSourcing\Enums;
 class MetaData
 {
     const AGGREGATE_ROOT_UUID = 'aggregate-root-uuid';
+    const AGGREGATE_ROOT_VERSION = 'aggregate-root-version';
 }

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -72,7 +72,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         $eloquentStoredEvent = new $this->storedEventModel();
 
         $eloquentStoredEvent->setOriginalEvent($event);
-        
+
         $eloquentStoredEvent->setRawAttributes([
             'event_properties' => app(EventSerializer::class)->serialize(clone $event),
             'aggregate_uuid' => $uuid,
@@ -91,8 +91,9 @@ class EloquentStoredEventRepository implements StoredEventRepository
     {
         $storedEvents = [];
 
+        /** @var \Spatie\EventSourcing\StoredEvents\ShouldBeStored $event */
         foreach ($events as $event) {
-            $storedEvents[] = $this->persist($event, $uuid, $aggregateVersion);
+            $storedEvents[] = $this->persist($event, $uuid, $event->aggregateRootVersion() ?? $aggregateVersion);
         }
 
         return new LazyCollection($storedEvents);

--- a/src/StoredEvents/ShouldBeStored.php
+++ b/src/StoredEvents/ShouldBeStored.php
@@ -20,6 +20,18 @@ abstract class ShouldBeStored
         return $this;
     }
 
+    public function aggregateRootVersion(): ?int
+    {
+        return $this->metaData[MetaData::AGGREGATE_ROOT_VERSION] ?? null;
+    }
+
+    public function setAggregateRootVersion(int $version): self
+    {
+        $this->metaData[MetaData::AGGREGATE_ROOT_VERSION] = $version;
+
+        return $this;
+    }
+
     public function metaData(): array
     {
         return $this->metaData;

--- a/stubs/create_stored_events_table.php.stub
+++ b/stubs/create_stored_events_table.php.stub
@@ -18,6 +18,8 @@ class CreateStoredEventsTable extends Migration
             $table->timestamp('created_at');
             $table->index('event_class');
             $table->index('aggregate_uuid');
+
+            $table->unique(['aggregate_uuid', 'aggregate_version']);
         });
     }
 }

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -10,6 +10,7 @@ use Spatie\EventSourcing\Exceptions\InvalidEloquentStoredEventModel;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\Snapshots\EloquentSnapshot;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
+use Spatie\EventSourcing\StoredEvents\StoredEvent;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootThatAllowsConcurrency;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithFailingPersist;
@@ -396,7 +397,7 @@ class AggregateRootTest extends TestCase
 
         Event::assertDispatched(MoneyMultiplied::class);
     }
-  
+
     public function it_can_load_the_uuid()
     {
         $aggregateRoot = (new AccountAggregateRoot())->loadUuid($this->aggregateUuid);

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -347,6 +347,7 @@ class AggregateRootTest extends TestCase
     /** @test */
     public function it_can_allow_to_be_persisted_from_concurrent_events()
     {
+        $this->markTestSkipped("\$allowConcurrency doesn't work anymore with the changes regarding race conditions in ARs.");
         $aggregateRoot = AccountAggregateRootThatAllowsConcurrency::retrieve($this->aggregateUuid);
         $aggregateRoot->addMoney(100);
 

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -10,7 +10,6 @@ use Spatie\EventSourcing\Exceptions\InvalidEloquentStoredEventModel;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\Snapshots\EloquentSnapshot;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
-use Spatie\EventSourcing\StoredEvents\StoredEvent;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootThatAllowsConcurrency;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithFailingPersist;


### PR DESCRIPTION
Fix for #170 

Note that a manual migration is required for this fix to work, and that `AggregateRoot::$allowConcurrency` cannot be used anymore if you've run that migration. Details can be found in the changelog.