### PR TITLE
Fix TypeError in EloquentStoredEvent Model

### DIFF
--- a/src/StoredEvents/Models/EloquentStoredEvent.php
+++ b/src/StoredEvents/Models/EloquentStoredEvent.php
@@ -14,7 +14,7 @@ use Spatie\SchemalessAttributes\SchemalessAttributes;
  */
 class EloquentStoredEvent extends Model
 {
-    public $guarded = [];
+    public array $guarded = [];
 
     public $timestamps = false;
 


### PR DESCRIPTION
This should fix a typeError
 Type of Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent::$guarded must be array (as in class Illuminate\Database\Eloquent\Model)