### PR TITLE
Update links in docs

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -2,5 +2,5 @@
 title: v5
 slogan: Event Sourcing for Artisans
 githubUrl: https://github.com/spatie/laravel-event-sourcing
-branch: master
+branch: main
 ---

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -3,4 +3,4 @@ title: Changelog
 weight: 6
 ---
 
-All notable changes to laravel-event-sourcing are documented [on GitHub](https://github.com/spatie/laravel-event-sourcing/blob/master/CHANGELOG.md)
+All notable changes to laravel-event-sourcing are documented [on GitHub](https://github.com/spatie/laravel-event-sourcing/blob/main/CHANGELOG.md)

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -31,6 +31,6 @@ The course includes:
 
 <section class="article_badges">
     <a href="https://github.com/spatie/laravel-event-sourcing/releases"><img src="https://img.shields.io/github/release/spatie/laravel-event-sourcing.svg?style=flat-square" alt="Latest Version"></a>
-    <a href="https://github.com/spatie/laravel-event-sourcing/blob/master/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square" alt="Software License"></a>
+    <a href="https://github.com/spatie/laravel-event-sourcing/blob/main/LICENSE.md"><img src="https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square" alt="Software License"></a>
     <a href="https://packagist.org/packages/spatie/laravel-event-sourcing"><img src="https://img.shields.io/packagist/dt/spatie/laravel-event-sourcing.svg?style=flat-square" alt="Total Downloads"></a>
 </section>

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -3,4 +3,4 @@ title: Upgrading
 weight: 7
 ---
 
-Instructions on how to upgrade from an earlier major version of `laravel-event-sourcing` are available  [on GitHub](https://github.com/spatie/laravel-event-sourcing/blob/master/UPGRADING.md)
+Instructions on how to upgrade from an earlier major version of `laravel-event-sourcing` are available  [on GitHub](https://github.com/spatie/laravel-event-sourcing/blob/main/UPGRADING.md)

--- a/docs/using-aggregates/writing-your-first-aggregate.md
+++ b/docs/using-aggregates/writing-your-first-aggregate.md
@@ -71,7 +71,7 @@ class AccountAggregate extends AggregateRoot
 
 The `recordThat` function will not persist the events to the database. It will simply hold them in memory. The events will get written to the database when the aggregate itself is persisted.
 
-There are two things to notice. First, the method names are written in the present tense, not the past tense. We're trying to do something, and for the rest of our application is hasn't happened yet until the actual `AccountCreated` is saved. This will only happen when the `AccountAggregate` gets persisted.
+There are two things to notice. First, the method names are written in the present tense, not the past tense. We're trying to do something, and for the rest of our application it hasn't happened yet until the actual `AccountCreated` is saved. This will only happen when the `AccountAggregate` gets persisted.
 
 The second thing to note is that nor the method and the event contain an uuid. The aggregate itself is aware of the uuid to use because it is passed to the retrieve method (`AccountAggregate::retrieve($uuid)`, we'll get to this in a bit). When persisting the aggregateroot, it will save the recorded events along with the uuid.
 


### PR DESCRIPTION
Changed `master` to `main` in docs and fixed a typo.