### PR TITLE
`$whenResult` should not be a string

### DIFF
--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -10,7 +10,7 @@ use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 
 class FakeAggregateRoot
 {
-    protected ?string $whenResult = null;
+    protected $whenResult = null;
 
     public function __construct(
         private AggregateRoot $aggregateRoot


### PR DESCRIPTION
I guess `$whenResult` should not be a string and it was type-hinted by mistake.

For example, my simple test case looks like:
```php
AccountAggregate::fake()
    ->given(new AccountCreated($account))
    ->when(fn(AccountAggregate $aggregate) => $aggregate->deposit($transaction))
    ->assertEventRecorded(new Deposited($transaction))
    ->assertNotRecorded(Withdrawn::class);
```

After upgrade to v5 it fails with the following error:
```php
TypeError : Cannot assign App\Aggregates\AccountAggregate to property Spatie\EventSourcing\AggregateRoots\FakeAggregateRoot::$whenResult of type ?string
 /home/vagrant/code/pfm/vendor/spatie/laravel-event-sourcing/src/AggregateRoots/FakeAggregateRoot.php:40
 /home/vagrant/code/pfm/tests/Unit/Aggregates/AssetAggregateTest.php:41
```