### PR TITLE
typo

### DIFF
--- a/docs/advanced-usage/using-your-own-event-serializer.md
+++ b/docs/advanced-usage/using-your-own-event-serializer.md
@@ -46,6 +46,7 @@ class UpgradeSerializer extends JsonEventSerializer
         return $event;
     }
 }
+```
 
 ## Want to know more?
 


### PR DESCRIPTION
fixed an missing **closing codeblock** (triple ticks) in the doc.