### PR TITLE
small suggestion: jsonb columns instead of json

### DIFF
--- a/database/migrations/create_snapshots_table.php.stub
+++ b/database/migrations/create_snapshots_table.php.stub
@@ -12,7 +12,7 @@ class CreateSnapshotsTable extends Migration
             $table->bigIncrements('id');
             $table->uuid('aggregate_uuid');
             $table->unsignedInteger('aggregate_version');
-            $table->json('state');
+            $table->jsonb('state');
 
             $table->timestamps();
 

--- a/database/migrations/create_stored_events_table.php.stub
+++ b/database/migrations/create_stored_events_table.php.stub
@@ -14,8 +14,8 @@ class CreateStoredEventsTable extends Migration
             $table->unsignedBigInteger('aggregate_version')->nullable();
             $table->integer('event_version')->default(1);
             $table->string('event_class');
-            $table->json('event_properties');
-            $table->json('meta_data');
+            $table->jsonb('event_properties');
+            $table->jsonb('meta_data');
             $table->timestamp('created_at');
             $table->index('event_class');
             $table->index('aggregate_uuid');


### PR DESCRIPTION
`jsonb` is generally considered [more performant](https://www.compose.com/articles/faster-operations-with-the-jsonb-data-type-in-postgresql/) than `json` 

on db's that don't support `jsonb`, Laravel will automatically fallback to `json`