### PR TITLE
Add backwards compatibility for eventId

### DIFF
--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -142,6 +142,7 @@ class StoredEvent implements Arrayable
             );
 
             $this->event->setMetaData(optional($this->meta_data)->toArray());
+            $this->event->setStoredEventId($this->id);
         } catch (Exception $exception) {
             throw InvalidStoredEvent::couldNotUnserializeEvent($this, $exception);
         }

--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -3,6 +3,7 @@
 namespace Spatie\EventSourcing\Tests\Models;
 
 use Carbon\Carbon;
+use Spatie\EventSourcing\Enums\MetaData;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\StoredEvents\Exceptions\InvalidStoredEvent;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
@@ -173,6 +174,17 @@ class StoredEventTest extends TestCase
         /** @var \Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent $eloquentEvent */
         $eloquentEvent = EloquentStoredEvent::first();
 
+        $event = $eloquentEvent->toStoredEvent()->event;
+
+        $this->assertEquals($eloquentEvent->id, $event->storedEventId());
+    }
+
+    /** @test */
+    public function the_stored_event_is_fetched_from_id_when_not_present_in_metadata()
+    {
+        $this->fireEvents();
+        $eloquentEvent = EloquentStoredEvent::first();
+        unset($eloquentEvent->meta_data[MetaData::STORED_EVENT_ID]);
         $event = $eloquentEvent->toStoredEvent()->event;
 
         $this->assertEquals($eloquentEvent->id, $event->storedEventId());


### PR DESCRIPTION
This PR introduces backwards compatibility for events that don't have the eventId in their metadata. 

Imho eventId shouldn't be in the metadata in the first place. This would also prevent saving, and immediately updating in the EloquentStoredEventRepository. Curious what the thoughts behind this are?