### PR TITLE
Fix AggregateRoot return types for static analysis

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -54,7 +54,7 @@ abstract class AggregateRoot
         return $aggregateRoot->reconstituteFromEvents();
     }
 
-    public function loadUuid(string $uuid): self
+    public function loadUuid(string $uuid): static
     {
         $this->uuid = $uuid;
 
@@ -66,7 +66,7 @@ abstract class AggregateRoot
         return $this->uuid;
     }
 
-    public function handleCommand(object $command): self
+    public function handleCommand(object $command): static
     {
         if ($handler = Handlers::find($command, $this)[0] ?? null) {
             $this->{$handler}($command);
@@ -89,7 +89,7 @@ abstract class AggregateRoot
         throw new UnhandledCommand($command::class);
     }
 
-    public function recordThat(ShouldBeStored $domainEvent): self
+    public function recordThat(ShouldBeStored $domainEvent): static
     {
         $domainEvent
             ->setAggregateRootUuid($this->uuid)
@@ -104,7 +104,7 @@ abstract class AggregateRoot
         return $this;
     }
 
-    public function persist(): self
+    public function persist(): static
     {
         $storedEvents = $this->persistWithoutApplyingToEventHandlers();
 
@@ -198,7 +198,7 @@ abstract class AggregateRoot
         return $recordedEvents;
     }
 
-    protected function reconstituteFromEvents(): self
+    protected function reconstituteFromEvents(): static
     {
         $storedEventRepository = $this->getStoredEventRepository();
 
@@ -289,7 +289,7 @@ abstract class AggregateRoot
         $projectionist->handleStoredEvents($storedEvents);
     }
 
-    private function disableEventHandling(): self
+    private function disableEventHandling(): static
     {
         $this->handleEvents = false;
 


### PR DESCRIPTION
When using a static analysis tool such as PHPStan, a type error is returned when using the following code snippet.

```php
namespace App\Aggregates;

use Spatie\EventSourcing\AggregateRoots\AggregateRoot;

class AccountAggregate extends AggregateRoot
{
    public function createAccount(string $name, string $userId): self
    {
        return $this->recordThat(new AccountCreated($name, $userId));
    }
}
```

```
Method App\Aggregates\AccountAggregate::add() should return App\Aggregates\AccountAggregate but returns Spatie\EventSourcing\AggregateRoots\AggregateRoot.
```

The problem is with the _short_ notation directly returning the result of the `recordThat` call. The return type resolves to `Spatie\EventSourcing\AggregateRoots\AggregateRoot`, instead of the current class due to the `self` return type. However, if we use the `static` return type, it is resolved correctly to the current class.