### PR TITLE
Fix urls pointing to previous version

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -114,7 +114,7 @@ return [
      * In production, you likely don't want the package to auto-discover the event handlers
      * on every request. The package can cache all registered event handlers.
      * More info:
-     * https://spatie.be/docs/laravel-event-sourcing/v4/advanced-usage/discovering-projectors-and-reactors#caching-discovered-projectors-and-reactors
+     * https://spatie.be/docs/laravel-event-sourcing/v5/advanced-usage/discovering-projectors-and-reactors#caching-discovered-projectors-and-reactors
      *
      * Here you can specify where the cache should be stored.
      */

--- a/docs/advanced-usage/discovering-projectors-and-reactors.md
+++ b/docs/advanced-usage/discovering-projectors-and-reactors.md
@@ -7,7 +7,7 @@ By default the package will automatically discover all projectors and reactors a
 
 If you want to see a list of the discovered projectors and reactors perform the `event-sourcing:list` Artisan command. Here's how the output could look like:
 
-<img src="/docs/laravel-event-sourcing/v4/images/list.png" />
+<img src="/docs/laravel-event-sourcing/v5/images/list.png" />
 
 ## Caching discovered projectors and reactors
 

--- a/docs/getting-familiar-with-event-sourcing/the-traditional-application.md
+++ b/docs/getting-familiar-with-event-sourcing/the-traditional-application.md
@@ -11,14 +11,14 @@ You might think that you still have the old state inside your backups. But they 
     <figcaption class="scheme_caption">
         First, we write value X
     </figcaption>
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/db-01.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/db-01.svg">
 </figure>
 
 <figure class="scheme">
     <figcaption class="scheme_caption">
         Next, we overwrite X by Y. X cannot be accessed anymore.
     </figcaption>
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/db-02.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/db-02.svg">
 </figure>
 
 Here's a demo application that uses a traditional architecture. Inside the [`AccountsController`](https://github.com/spatie/larabank-traditional/blob/9cc38858c50a4f2ac5a36e64719c891fac85bd3f/app/Http/Controllers/AccountsController.php) we are just going to [create new accounts](https://github.com/spatie/larabank-traditional/blob/9cc38858c50a4f2ac5a36e64719c891fac85bd3f/app/Http/Controllers/AccountsController.php#L19-L27) and [update the balance](https://github.com/spatie/larabank-traditional/blob/9cc38858c50a4f2ac5a36e64719c891fac85bd3f/app/Http/Controllers/AccountsController.php#L29-L36). We're using an eloquent model to update the database. Whenever we change the balance of the account, the old value is lost.

--- a/docs/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past.md
+++ b/docs/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past.md
@@ -12,25 +12,25 @@ Let's go through this step by step.
 Step 1: our app wants to subtract $1000. We create a new aggregate root instance and will feed it all events. There are no events yet to retrieve in this pass. The aggregate will conclude that it's allowed to subtract $1000 and will record that `Subtract` event. This recording is just in memory, and nothing will be written to the DB yet.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/aggregate-01.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-01.svg">
 </figure>
 
 Step 2: We are going to persist the aggregate. When persisting an aggregate, all of the newly recorded events that aggregate will be written in the database. Also, if you have projectors set up, they will receive the newly persisted events as well.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/aggregate-02.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-02.svg">
 </figure>
 
 Step 3: Let's hit that account limit and try to subtract $4800 now. First, the aggregate will be reconstituted from all previous events. Because it gets the earlier events it can calculate the current balance in memory (which is of course -$1000). The aggregate root can conclude that if we were to subtract $4800 we would cross our limit of -$5000. So it is not going to record that event. Instead, we could record that fact the account limit was hit.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/aggregate-03.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-03.svg">
 </figure>
 
 Step 4: The aggregate gets persisted, and the account limit hit event gets written into the database.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/aggregate-04.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-04.svg">
 </figure>
 
 So now we've protected our account from going below -\$5000. Let's take it one step further and send our customer a loan proposal mail when he or she hits the account limit three times in a row. Using an aggregate this is easy!
@@ -38,13 +38,13 @@ So now we've protected our account from going below -\$5000. Let's take it one s
 Step 5: Let's again try to subtract a lot of money to hit that account limit of \$5000. We hit our account limit the second time.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/aggregate-05.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-05.svg">
 </figure>
 
 Step 6: This time it gets interesting. We are going to try to subtract money and will hit our limit for the third time. Our aggregate gets reconstituted from all events. Those events get fed to the aggregate one by one. The aggregate in memory holds a counter of how many limit hit events it receives. That counter is now on 2. Because the amount we subtract will take us over the account limit, the aggregate will not record a subtract event, but a new limit hit event. It will update the limit hit counter from 2 to 3. Because the counter is now at 3. It can also record a new event called loan proposed. When storing the aggregate, the new events will get persisted in the database. All projectors and reactor will get called with these events. The `LoanProposalReactor` hears that `LoanProposed` event and send the mail.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/aggregate-06.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-06.svg">
 </figure>
 
 All of the above is a lot to wrap your mind around. To help you understand this better, here's our Larabank app again, but this time built [using aggregates](https://github.com/spatie/larabank-aggregates). In the controller, you see that we don't fire events, but we are [using an aggregate](https://github.com/spatie/larabank-aggregates/blob/cc9c85fb6569aa9259fe7f9bdd5ee23ec92b0c66/app/Http/Controllers/AccountsController.php#L21-L52). Inside the aggregate we are going to [record events](https://github.com/spatie/larabank-aggregates/blob/cc9c85fb6569aa9259fe7f9bdd5ee23ec92b0c66/app/Domain/Account/AccountAggregateRoot.php#L34) that will get written to the database as soon as we [persist](https://github.com/spatie/larabank-aggregates/blob/cc9c85fb6569aa9259fe7f9bdd5ee23ec92b0c66/app/Http/Controllers/AccountsController.php#L40) the aggregate.

--- a/docs/getting-familiar-with-event-sourcing/using-projectors-to-transform-events.md
+++ b/docs/getting-familiar-with-event-sourcing/using-projectors-to-transform-events.md
@@ -11,26 +11,26 @@ Instead of directly updating the value in the database, we could write every cha
     <figcaption class="scheme_caption">
         Here we write our first event in the database
     </figcaption>
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/transform-01.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/transform-01.svg">
 </figure>
 
 <figure class="scheme">
     <figcaption class="scheme_caption">
         When new events come in, we'll write them to the events table as well
     </figcaption>
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/transform-02.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/transform-02.svg">
 </figure>
 
 All events get passed to a class we call a projector. The projector transforms the events to a format that is handy to use in our app. In our Larabank example, the events table hold the info of the individual transactions like `MoneyAdded` and `MoneySubtracted`. A projector could build an `Accounts` table based on those transactions.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/transform-03.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/transform-03.svg">
 </figure>
 
 Imagine that you've already stored some events, and your first projector is doing its job creating that `Accounts` table. The bank director now wants to know on which accounts the most transactions were performed. No problem, we could create another projector that reads all previous events and adds the `MoneyAdded` and `MoneySubtracted` events to make projections.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v4/images/transform-04.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/transform-04.svg">
 </figure>
 
 This package can help you store native Laravel events in a `stored_events` table and create projectors that transform those events.


### PR DESCRIPTION
Some urls still point to v4 which can cause confusion. This PR fixes that.

PS. Can the `hacktoberfest-accepted` label be added on the PR? 🥳 