### PR TITLE
shouldDispatchJob to only count async handlers which handle the current stored event

### DIFF
--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -8,6 +8,7 @@ use Illuminate\Support\Arr;
 use ReflectionClass;
 use ReflectionException;
 use Spatie\EventSourcing\Attributes\EventSerializer as EventSerializerAttribute;
+use Spatie\EventSourcing\EventHandlers\EventHandler;
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\StoredEvents\Exceptions\InvalidStoredEvent;
@@ -104,7 +105,8 @@ class StoredEvent implements Arrayable
     protected function shouldDispatchJob(): bool
     {
         /** @var \Spatie\EventSourcing\EventHandlers\EventHandlerCollection $eventHandlers */
-        $eventHandlers = Projectionist::allEventHandlers();
+        $eventHandlers = Projectionist::allEventHandlers()
+        ->filter(fn (EventHandler $eventHandler) => in_array($this->event_class, $eventHandler->handles(), true));
 
         return $eventHandlers->asyncEventHandlers()->count() > 0;
     }


### PR DESCRIPTION
I observed that all of the events were are sent to the queue even when projector/reactor did not extend `ShouldQueue`. While debugging found the codeblock in the StoredEvent class, where the method `shouldDispatchJob` returns a boolean if the job should be dispatched or not.

In the shouldDispatchJob method, it currently gets all allEventHandlers and checks if there is a projector or reactor which implements ShouldQueue. If the count is greater than 0, then this event handling needs to be queued.
```php
protected function shouldDispatchJob(): bool
    {
        /** @var \Spatie\EventSourcing\EventHandlers\EventHandlerCollection $eventHandlers */
        $eventHandlers = Projectionist::allEventHandlers();

        return $eventHandlers->asyncEventHandlers()->count() > 0;
    }
```
However, as it is getting all event handlers instead of getting the ones which listen to current event, every event is sent to the queue. In practice, there might be a handler which does not handle current event but it is still queued. So in that case we do not want to put the event in queue.

Interestingly, this logic was present before. Seems like it was removed in one of the updates to V5? 
https://github.com/spatie/laravel-event-sourcing/commit/3df26eaaf5e59f0bef9b5543ab67802da0595bc0?branch=3df26eaaf5e59f0bef9b5543ab67802da0595bc0&diff=split#diff-f052e57fc1d9a4db9291fa2e4b5c8e833289fa64c667111392bb2a4dfe8fcd9d

Not putting something in queue which is not getting processed by a queue worker is important. Because you might be using SQS and serverless lambda(e.g. vapor). It adds invocation costs every time a worker is trying to process something.

This PR updated this method to only account for handlers which handle current stored event class.