### PR TITLE
Changed cursor() into lazyById() to preserve memory when working with large amount of events

### DIFF
--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -51,7 +51,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         /** @var LazyCollection $lazyCollection */
         $lazyCollection = $query
             ->orderBy('id')
-            ->cursor();
+            ->lazyById();
 
         return $lazyCollection->map(fn (EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }


### PR DESCRIPTION
In one of my projects I have several millions of events and when I tried to replay them all, my process was dying because of being out of memory. I have solved this issue by changing cursor() into lazyById()