### PR TITLE
Fixed tests/VersionedEventTest.php which was not passing due to invalid arguments being given.

### DIFF
--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -51,7 +51,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         /** @var LazyCollection $lazyCollection */
         $lazyCollection = $query
             ->orderBy('id')
-            ->cursor();
+            ->lazyById();
 
         return $lazyCollection->map(fn (EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }

--- a/tests/VersionedEventTest.php
+++ b/tests/VersionedEventTest.php
@@ -32,7 +32,7 @@ class VersionedEventTest extends TestCase
             "aggregate_version" => null,
             "event_version" => 1,
             "event_class" => "Spatie\\EventSourcing\\Tests\\VersionedEvent",
-            "event_properties" => ['name' => 'event-1'],
+            "event_properties" => ['uuid' => 'event-1'],
             "meta_data" => [],
             "created_at" => now(),
         ]);


### PR DESCRIPTION
I wanted to see if all tests pass, but I found that tests/VersionedEventTest.php::a_versioned_event_can_be_restored test wasn't passing, after short debugging I found that instead of required argument "uuid", "name" argument was given to Event class. 