### PR TITLE
Fixed tests/VersionedEventTest.php::a_versioned_event_can_be_restored 

### DIFF
--- a/tests/VersionedEventTest.php
+++ b/tests/VersionedEventTest.php
@@ -32,7 +32,7 @@ class VersionedEventTest extends TestCase
             "aggregate_version" => null,
             "event_version" => 1,
             "event_class" => "Spatie\\EventSourcing\\Tests\\VersionedEvent",
-            "event_properties" => ['name' => 'event-1'],
+            "event_properties" => ['uuid' => 'event-1'],
             "meta_data" => [],
             "created_at" => now(),
         ]);


### PR DESCRIPTION
Phpunit tests failed in `a_versioned_event_can_be_restored` method of `tests/VersionedEventTest.php` due to 'uuid' property not being passed. As I have seen, event was being given `name` instead of `uuid` argument with correct value, so I have simply renamed property and test passes once again. 