### PR TITLE
Set minimum version of illuminate/database to ^8.34

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,10 @@
         }
     ],
     "require": {
-        "php": "^8.0",
+        "php": "^8.0.0",
         "ext-json": "*",
         "illuminate/console": "^8.0",
-        "illuminate/database": "^8.0",
+        "illuminate/database": "^8.34",
         "illuminate/events": "^8.0",
         "illuminate/support": "^8.0",
         "league/flysystem": "^1.1.3",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": "^8.0.0",
+        "php": "^8.0",
         "ext-json": "*",
         "illuminate/console": "^8.0",
         "illuminate/database": "^8.34",


### PR DESCRIPTION
This change is required because lazyById method is available from illuminate/database 8.34 version. 