### PR TITLE
Aggregate tests without db

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -201,7 +201,7 @@ abstract class AggregateRoot
         }
     }
 
-    public function getAndClearRecordedEvents(): array
+    protected function getAndClearRecordedEvents(): array
     {
         $recordedEvents = $this->recordedEvents;
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -201,7 +201,7 @@ abstract class AggregateRoot
         }
     }
 
-    protected function getAndClearRecordedEvents(): array
+    public function getAndClearRecordedEvents(): array
     {
         $recordedEvents = $this->recordedEvents;
 

--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -30,7 +30,7 @@ class FakeAggregateRoot
             $this->aggregateRoot->recordThat($event);
         }
 
-        $this->aggregateRoot->persist();
+        $this->aggregateRoot->getAndClearRecordedEvents();
 
         return $this;
     }

--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -11,6 +11,7 @@ use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 class FakeAggregateRoot
 {
     protected $whenResult = null;
+    protected $givenEventsCount = 0;
 
     public function __construct(
         private AggregateRoot $aggregateRoot
@@ -30,7 +31,7 @@ class FakeAggregateRoot
             $this->aggregateRoot->recordThat($event);
         }
 
-        $this->aggregateRoot->getAndClearRecordedEvents();
+        $this->givenEventsCount = count($events);
 
         return $this;
     }
@@ -170,6 +171,6 @@ class FakeAggregateRoot
             unset($metaData[MetaData::AGGREGATE_ROOT_VERSION]);
 
             return $event->setMetaData($metaData);
-        }, $this->aggregateRoot->getRecordedEvents());
+        }, array_slice($this->aggregateRoot->getRecordedEvents(), $this->givenEventsCount));
     }
 }


### PR DESCRIPTION
This issue solves #276 

I assume the `persist` was used to clear the events so that we could easily see what events were recorded during the `when` stage. 

The [first POC](https://github.com/spatie/laravel-event-sourcing/commit/d6814bcd6ef63ffc573cf8350c1bbce766620dd2) of this was to simply call the `getAndClearRecordedEvents` on the AggregateRoot. 

However, we can achieve the same result by simply [remembering how many `given` events there were](https://github.com/morrislaptop/laravel-event-sourcing/blob/56fdc8f47a7ca525eafc632839db9a9c9f3f6414/src/AggregateRoots/FakeAggregateRoot.php#L34) and [removing them](https://github.com/morrislaptop/laravel-event-sourcing/blob/56fdc8f47a7ca525eafc632839db9a9c9f3f6414/src/AggregateRoots/FakeAggregateRoot.php#L174) when doing our assertions.