### PR TITLE
skip retrieve on aggregate::fake

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -285,7 +285,8 @@ abstract class AggregateRoot
     {
         $uuid ??= (string) Str::uuid();
 
-        $aggregateRoot = static::retrieve($uuid)->disableEventHandling();
+        $aggregateRoot = app(static::class)->disableEventHandling();
+        $aggregateRoot->uuid = $uuid;
 
         return (new FakeAggregateRoot($aggregateRoot));
     }


### PR DESCRIPTION
Follow up on #292 from https://github.com/spatie/laravel-event-sourcing/pull/292#issuecomment-979821746

If we are calling the fake method can we assume there'll be no prior events and skip the `retrieve` method.