### PR TITLE
Don't mutate original events in `FakeAggregateRoot::getRecordedEventsWithoutUuid`

### DIFF
--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -122,6 +122,7 @@ class FakeAggregateRoot
         $expectedEvents = Arr::wrap($expectedEvents);
 
         $appliedEvents = array_map(function (ShouldBeStored $event) {
+            $eventWithoutUuid = clone $event;
             $metaData = $event->metaData();
 
             unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
@@ -129,7 +130,7 @@ class FakeAggregateRoot
             unset($metaData[MetaData::CREATED_AT]);
             unset($metaData[MetaData::AGGREGATE_ROOT_VERSION]);
 
-            return $event->setMetaData($metaData);
+            return $eventWithoutUuid->setMetaData($metaData);
         }, $this->aggregateRoot->getAppliedEvents());
 
         Assert::assertEquals($expectedEvents, $appliedEvents);
@@ -163,6 +164,7 @@ class FakeAggregateRoot
     private function getRecordedEventsWithoutUuid(): array
     {
         return array_map(static function (ShouldBeStored $event) {
+            $eventWithoutUuid = clone $event;
             $metaData = $event->metaData();
 
             unset($metaData[MetaData::AGGREGATE_ROOT_UUID]);
@@ -170,7 +172,7 @@ class FakeAggregateRoot
             unset($metaData[MetaData::CREATED_AT]);
             unset($metaData[MetaData::AGGREGATE_ROOT_VERSION]);
 
-            return $event->setMetaData($metaData);
+            return $eventWithoutUuid->setMetaData($metaData);
         }, array_slice($this->aggregateRoot->getRecordedEvents(), $this->givenEventsCount));
     }
 }


### PR DESCRIPTION
When you use something like `assertRecorded` on an aggregate root fake, it calls `getRecordedEventsWithoutUuid`:

https://github.com/spatie/laravel-event-sourcing/blob/01b17e0ba6d1795acf7b91db5475b7a0a36ea4ac/src/AggregateRoots/FakeAggregateRoot.php#L163-L175

This method removes any generated metadata from the event so that it can be safely compared, but it mutates the original event instead of cloning it or creating a new copy. This means that if you then want to use the events on the aggregate root later in your test, those metadata values are gone.

This PR just clones the event before mutating it so that if you need the generated metadata later in your test it is still available.