### PR TITLE
Exclude given events in FakeAggregateRoot::assertNotRecorded

### DIFF
--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -85,7 +85,7 @@ class FakeAggregateRoot
 
     public function assertNotRecorded($unexpectedEventClasses): self
     {
-        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->aggregateRoot->getRecordedEvents());
+        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->getRecordedEventsWithoutUuid());
 
         $unexpectedEventClasses = Arr::wrap($unexpectedEventClasses);
 

--- a/tests/FakeAggregateRootTest.php
+++ b/tests/FakeAggregateRootTest.php
@@ -155,6 +155,14 @@ class FakeAggregateRootTest extends TestCase
     }
 
     /** @test */
+    public function it_excludes_given_events_to_assert_that_an_event_is_not_recorded()
+    {
+        DummyAggregateRoot::fake()
+            ->given([new DummyEvent(1)])
+            ->assertNotRecorded(DummyEvent::class);
+    }
+
+    /** @test */
     public function it_can_assert_that_an_event_is_not_applied()
     {
         DummyAggregateRoot::fake()->assertNotApplied(DummyEvent::class);


### PR DESCRIPTION
In the documentation about testing aggregate (https://spatie.be/docs/laravel-event-sourcing/v5/using-aggregates/testing-aggregates), there is this example 

```php
/** @test */
public function it_will_not_make_subtractions_that_would_go_below_the_account_limit()
{
    AccountAggregateRoot::fake()
        ->given([new AccountCreated('Luke'), new MoneySubtracted(4999)])
        ->when(function (AccountAggregate $accountAggregate) {
            $accountAggregate->subtractMoney(2);
        })
        ->assertRecorded(new AccountLimitHit(2))
        ->assertNotRecorded(MoneySubtracted::class);
}
```

Actually this test fails to assert that `MoneySubstracted` was not recorded because it is given in the FakeAggregateRoot.

This PR fixes it. 