### PR TITLE
Add line break to increase readability

### DIFF
--- a/docs/using-aggregates/testing-aggregates.md
+++ b/docs/using-aggregates/testing-aggregates.md
@@ -124,7 +124,8 @@ When calling the `given` method the aggregate will fire of events for your proje
 If you would prefer to disable Projectors reacting to events whilst retaining `Event` functionality simply use the `Projectionist` facade's `withoutEventHandlers` method before your test executes.
 
 ```php
-use Spatie\EventSourcing\Facades\Projectionist;Projectionist::withoutEventHandlers();
+use Spatie\EventSourcing\Facades\Projectionist;
+Projectionist::withoutEventHandlers();
 ```
 
 ## Want to know more?


### PR DESCRIPTION
Add a line break so use statement and call to static method are on separate lines