### PR TITLE
Change event_version column type from int to unsigned tinyint

### DIFF
--- a/database/migrations/create_stored_events_table.php.stub
+++ b/database/migrations/create_stored_events_table.php.stub
@@ -12,7 +12,7 @@ class CreateStoredEventsTable extends Migration
             $table->bigIncrements('id');
             $table->uuid('aggregate_uuid')->nullable();
             $table->unsignedBigInteger('aggregate_version')->nullable();
-            $table->integer('event_version')->default(1);
+            $table->unsignedTinyInteger('event_version')->default(1);
             $table->string('event_class');
             $table->jsonb('event_properties');
             $table->jsonb('meta_data');


### PR DESCRIPTION
Changed the `event_version` column type from int to unsigned tinyint in the `stored_events` table migration stub.

The event version shouldn't be negative, therefore, the new column type would be more semantically correct for the use-case of this feature