### PR TITLE
Snapshotting of aggregate partial

### DIFF
--- a/docs/advanced-usage/aggregate-partials.md
+++ b/docs/advanced-usage/aggregate-partials.md
@@ -13,10 +13,12 @@ Here's an example of an aggregate partial, which manages cart items and is part 
 namespace Spatie\Shop\Cart\Partials;
 
 use Spatie\EventSourcing\AggregateRoots\AggregatePartial;
+use Spatie\EventSourcing\Attributes\IncludeInSnapshot;
 
 class CartItems extends AggregatePartial
 {
-    private array $cartItems = [];
+    #[IncludeInSnapshot]
+    protected array $cartItems = [];
 
     public function isEmpty(): bool
     {

--- a/src/Attributes/IncludeInSnapshot.php
+++ b/src/Attributes/IncludeInSnapshot.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\EventSourcing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_PROPERTY)]
+final class IncludeInSnapshot
+{
+}


### PR DESCRIPTION
Only public properties are includes in snapshots currently.
This change adds the feature to automatically include all
aggregate partials in the snapshot. Also added a small
feature that allows to also include internal state in the
snapshot by adding an attribute to the property that should
be included.

Resolves: #307