### PR TITLE
Laravel 9.x Compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,11 +12,9 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 8.1]
-                laravel: [8.*, 9.*]
+                laravel: [9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
-                    - laravel: 8.*
-                      testbench: ^6.23
                     - laravel: 9.*
                       testbench: 7.*
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,11 +12,13 @@ jobs:
         strategy:
             matrix:
                 php: [8.0, 8.1]
-                laravel: [8.*]
+                laravel: [8.*, 9.*]
                 dependency-version: [prefer-lowest, prefer-stable]
                 include:
                     - laravel: 8.*
                       testbench: ^6.23
+                    - laravel: 9.*
+                      testbench: 7.*
 
         name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "illuminate/database": "^8.67",
         "illuminate/events": "^8.67",
         "illuminate/support": "^8.67",
-        "league/flysystem": "^1.1.3",
         "phpdocumentor/reflection-docblock": "^5.2",
         "spatie/better-types": "0.1.0",
         "spatie/laravel-package-tools": "^1.9",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/events": "^8.67|^9.0",
         "illuminate/support": "^8.67|^9.0",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "spatie/better-types": "0.1.0",
+        "spatie/better-types": "^0.1.0",
         "spatie/laravel-package-tools": "^1.9",
         "spatie/laravel-schemaless-attributes": "^1.0|^2.0",
         "symfony/finder": "^5.3.7|^6.0",

--- a/composer.json
+++ b/composer.json
@@ -23,23 +23,23 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/console": "^8.67",
-        "illuminate/database": "^8.67",
-        "illuminate/events": "^8.67",
-        "illuminate/support": "^8.67",
+        "illuminate/console": "^8.67|^9.0",
+        "illuminate/database": "^8.67|^9.0",
+        "illuminate/events": "^8.67|^9.0",
+        "illuminate/support": "^8.67|^9.0",
         "phpdocumentor/reflection-docblock": "^5.2",
         "spatie/better-types": "0.1.0",
         "spatie/laravel-package-tools": "^1.9",
         "spatie/laravel-schemaless-attributes": "^1.0|^2.0",
-        "symfony/finder": "^5.3.7",
-        "symfony/property-access": "^5.3",
-        "symfony/property-info": "^5.3",
-        "symfony/serializer": "^5.3"
+        "symfony/finder": "^5.3.7|^6.0",
+        "symfony/property-access": "^5.3|^6.0",
+        "symfony/property-info": "^5.3|^6.0",
+        "symfony/serializer": "^5.3|^6.0"
     },
     "require-dev": {
         "laravel/horizon": "^5.7",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^6.23",
+        "orchestra/testbench": "^6.23|^7.0",
         "phpunit/phpunit": "^9.5.10",
         "spatie/fork": "^1.0",
         "spatie/phpunit-snapshot-assertions": "^4.0"

--- a/composer.json
+++ b/composer.json
@@ -23,23 +23,23 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/console": "^8.67|^9.0",
-        "illuminate/database": "^8.67|^9.0",
-        "illuminate/events": "^8.67|^9.0",
-        "illuminate/support": "^8.67|^9.0",
+        "illuminate/console": "^9.0",
+        "illuminate/database": "^9.0",
+        "illuminate/events": "^9.0",
+        "illuminate/support": "^9.0",
         "phpdocumentor/reflection-docblock": "^5.2",
         "spatie/better-types": "^0.1.0",
         "spatie/laravel-package-tools": "^1.9",
-        "spatie/laravel-schemaless-attributes": "^1.0|^2.0",
-        "symfony/finder": "^5.3.7|^6.0",
-        "symfony/property-access": "^5.3|^6.0",
-        "symfony/property-info": "^5.3|^6.0",
-        "symfony/serializer": "^5.3|^6.0"
+        "spatie/laravel-schemaless-attributes": "^2.0",
+        "symfony/finder": "^6.0",
+        "symfony/property-access": "^6.0",
+        "symfony/property-info": "^6.0",
+        "symfony/serializer": "^6.0"
     },
     "require-dev": {
         "laravel/horizon": "^5.7",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^6.23|^7.0",
+        "orchestra/testbench": "^7.0",
         "phpunit/phpunit": "^9.5.10",
         "spatie/fork": "^1.0",
         "spatie/phpunit-snapshot-assertions": "^4.0"

--- a/src/Support/CarbonNormalizer.php
+++ b/src/Support/CarbonNormalizer.php
@@ -13,7 +13,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritdoc
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize(mixed $object, string $format = null, array $context = []): string
     {
         if (! $object instanceof CarbonInterface) {
             throw new InvalidArgumentException('Cannot serialize an object that is not a CarbonInterface in CarbonNormalizer.');
@@ -25,7 +25,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritdoc
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization(mixed $data, string $format = null): bool
     {
         return $data instanceof CarbonInterface;
     }
@@ -33,7 +33,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritDoc
      */
-    public function denormalize($data, $class, string $format = null, array $context = [])
+    public function denormalize(mixed $data, string $class, string $format = null, array $context = []): CarbonInterface
     {
         return Date::parse($data);
     }
@@ -41,7 +41,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritDoc
      */
-    public function supportsDenormalization($data, $type, string $format = null)
+    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
     {
         return is_a($type, CarbonInterface::class, true);
     }

--- a/src/Support/ModelIdentifierNormalizer.php
+++ b/src/Support/ModelIdentifierNormalizer.php
@@ -2,11 +2,11 @@
 
 namespace Spatie\EventSourcing\Support;
 
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Queue\SerializesAndRestoresModelIdentifiers;
 use InvalidArgumentException;
 use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;

--- a/src/Support/ModelIdentifierNormalizer.php
+++ b/src/Support/ModelIdentifierNormalizer.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\EventSourcing\Support;
 
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Contracts\Database\ModelIdentifier;
 use Illuminate\Contracts\Queue\QueueableCollection;
 use Illuminate\Contracts\Queue\QueueableEntity;
@@ -17,19 +19,19 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function normalize($object, string $format = null, array $context = [])
+    public function normalize(mixed $object, string $format = null, array $context = []): array
     {
         if (! $this->supportsNormalization($object)) {
             throw new InvalidArgumentException('Cannot serialize an object that is not a QueueableEntity or QueueableCollection in ModelIdentifierNormalizer.');
         }
 
-        return $this->getSerializedPropertyValue($object);
+        return (array) $this->getSerializedPropertyValue($object);
     }
 
     /**
      * @inheritdoc
      */
-    public function supportsNormalization($data, string $format = null)
+    public function supportsNormalization(mixed $data, string $format = null): bool
     {
         return ($data instanceof QueueableEntity || $data instanceof QueueableCollection);
     }
@@ -37,7 +39,7 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function denormalize($data, $class, string $format = null, array $context = [])
+    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): Collection|Model
     {
         $identifier = $data instanceof ModelIdentifier
             ? $data
@@ -49,7 +51,7 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function supportsDenormalization($data, $type, string $format = null)
+    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
     {
         return $this->normalizedDataIsModelIdentifier($data)
             && $this->isNormalizedToModelIdentifier($type);


### PR DESCRIPTION
The `league/flyststem` requirement had to be widened to include `^2.0` as well. However, I noticed that we're not using any code from that package explicitly anyway, so I removed it.

EDIT:

I accidentally based this PR on an older version of the package. I see that it's blocked by https://github.com/spatie/better-types now, as it requires `illuminate/collections:^8.58`, but I've also opened a PR to address this issue https://github.com/spatie/better-types/pull/2.