### PR TITLE
Resolves issue with meta data updating on original event.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -58,7 +58,6 @@
         ]
     },
     "scripts": {
-        "psalm": "vendor/bin/psalm",
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },

--- a/src/StoredEvents/Models/EloquentStoredEvent.php
+++ b/src/StoredEvents/Models/EloquentStoredEvent.php
@@ -59,7 +59,9 @@ class EloquentStoredEvent extends Model
 
     public function getEventAttribute(): ?ShouldBeStored
     {
-        return ($event = $this->getOriginalEvent()) ? $event : $this->toStoredEvent()->event;
+        return ($event = $this->getOriginalEvent())
+            ? $event
+            : $this->originalEvent = $this->toStoredEvent()->event;
     }
 
     public function getMetaDataAttribute(): SchemalessAttributes

--- a/src/StoredEvents/Models/EloquentStoredEvent.php
+++ b/src/StoredEvents/Models/EloquentStoredEvent.php
@@ -38,7 +38,7 @@ class EloquentStoredEvent extends Model
             'event_class' => $this->event_class,
             'meta_data' => $this->meta_data,
             'created_at' => $this->created_at,
-        ], $this->originalEvent);
+        ], $this->getOriginalEvent());
     }
 
     public function setOriginalEvent(ShouldBeStored $event): self
@@ -48,9 +48,18 @@ class EloquentStoredEvent extends Model
         return $this;
     }
 
+    public function getOriginalEvent(): ?ShouldBeStored
+    {
+        if ($this->isDirty('meta_data')) {
+            $this->originalEvent?->setMetaData($this->meta_data?->toArray() ?? []);
+        }
+
+        return $this->originalEvent;
+    }
+
     public function getEventAttribute(): ?ShouldBeStored
     {
-        return $this->originalEvent ??= $this->toStoredEvent()->event;
+        return ($event = $this->getOriginalEvent()) ? $event : $this->toStoredEvent()->event;
     }
 
     public function getMetaDataAttribute(): SchemalessAttributes

--- a/src/StoredEvents/Models/EloquentStoredEvent.php
+++ b/src/StoredEvents/Models/EloquentStoredEvent.php
@@ -50,7 +50,7 @@ class EloquentStoredEvent extends Model
 
     public function getOriginalEvent(): ?ShouldBeStored
     {
-        if ($this->isDirty('meta_data')) {
+        if ($this->isDirty('meta_data') || $this->wasChanged('meta_data')) {
             $this->originalEvent?->setMetaData($this->meta_data?->toArray() ?? []);
         }
 

--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -149,6 +149,23 @@ class StoredEventTest extends TestCase
     }
 
     /** @test */
+    public function it_updates_the_original_if_meta_data_is_changed()
+    {
+        $originalEvent = new MoneyAdded(100);
+
+        $eloquentStoredEvent = new EloquentStoredEvent();
+
+        $eloquentStoredEvent->setOriginalEvent($originalEvent);
+
+        $eloquentStoredEvent->meta_data->set('user.id', 1);
+
+        $this->assertEqualsCanonicalizing(
+            $eloquentStoredEvent->meta_data->toArray(),
+            $eloquentStoredEvent->event->metaData()
+        );
+    }
+
+    /** @test */
     public function created_at_is_set_on_event()
     {
         $now = Carbon::make('2021-01-01 10:00:00');


### PR DESCRIPTION
As noted in #270 and #271, there is a bug with the `EloquentStoredEvent` model that causes meta data changes to not be passed on to projectors and reactors the first time the event handled. Subsequent replays will correctly pass the meta data since the "cached" original event is re-created based on meta data in the database. This was a bug originally introduced in #158.

This PR provides a test for the expected functionality and a fix for the bug. The current approach being to check if the `meta_data` attribute is dirty and update the original event if so. While we could add a check for other attributes on the model, I don't think we gain as much value by doing so since those should basically be immutable.

**Side note:** I removed the unused Psalm script from the composer file since it does not appear Psalm is listed as a dependency, and no workflow runs it.