### PR TITLE
Adds query helpers for event properties

### DIFF
--- a/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
+++ b/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
@@ -37,7 +37,7 @@ class EloquentStoredEventQueryBuilder extends Builder
         return $this;
     }
 
-    public function whereProperty(string $property, mixed $value): self
+    public function wherePropertyIs(string $property, mixed $value): self
     {
         $this->whereJsonContains(column: "event_properties->{$property}", value: $value);
 

--- a/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
+++ b/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
@@ -36,4 +36,18 @@ class EloquentStoredEventQueryBuilder extends Builder
 
         return $this;
     }
+
+    public function whereProperty(string $property, mixed $value): self
+    {
+        $this->whereJsonContains(column: "event_properties->{$property}", value: $value);
+
+        return $this;
+    }
+
+    public function wherePropertyIsNot(string $property, mixed $value): self
+    {
+        $this->whereJsonDoesntContain(column: "event_properties->{$property}", value: $value);
+
+        return $this;
+    }
 }

--- a/tests/Models/EloquentStoredEventQueryBuilderTest.php
+++ b/tests/Models/EloquentStoredEventQueryBuilderTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\Models;
+
+use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
+use Spatie\EventSourcing\Tests\TestCase;
+
+class EloquentStoredEventQueryBuilderTest extends TestCase
+{
+    /** @test */
+    public function it_constrains_to_property_value()
+    {
+        $expected = EloquentStoredEvent::query()->whereJsonContains(
+            column: 'event_properties->otherEntityId', value: 10
+        );
+
+        $actual = EloquentStoredEvent::query()->wherePropertyIs(
+            property: 'otherEntityId', value: 10
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+
+    /** @test */
+    public function it_constrains_to_property_value_difference()
+    {
+        $expected = EloquentStoredEvent::query()->whereJsonDoesntContain(
+            column: 'event_properties->name', value: 'Johnson'
+        );
+
+        $actual = EloquentStoredEvent::query()->wherePropertyIsNot(
+            property: 'name', value: 'Johnson'
+        );
+
+        $this->assertEquals($expected, $actual);
+    }
+}


### PR DESCRIPTION
This PR adds two methods `wherePropertyIs()` and `wherePropertyIsNot()` to the stored event query builder. These allow you to perform lookups against event properties and utilize the `whereJsonContains` methods. As an example, we have had to use this when querying for all events for a company.

**Example:**

```php
EloquentStoredEvent::query()
    ->whereEvent(CompanyOptedOutOfEmails::class)
    ->wherePropertyIs('companyId', 'ABC-123-XYZ')
    ->get();
```