### PR TITLE
Update migration file to closure

### DIFF
--- a/database/migrations/create_snapshots_table.php.stub
+++ b/database/migrations/create_snapshots_table.php.stub
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('snapshots', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->uuid('aggregate_uuid');
             $table->unsignedInteger('aggregate_version');
             $table->jsonb('state');

--- a/database/migrations/create_snapshots_table.php.stub
+++ b/database/migrations/create_snapshots_table.php.stub
@@ -4,9 +4,9 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateSnapshotsTable extends Migration
+return new class extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('snapshots', function (Blueprint $table) {
             $table->bigIncrements('id');
@@ -19,4 +19,4 @@ class CreateSnapshotsTable extends Migration
             $table->index('aggregate_uuid');
         });
     }
-}
+};

--- a/database/migrations/create_stored_events_table.php.stub
+++ b/database/migrations/create_stored_events_table.php.stub
@@ -4,9 +4,9 @@ use Illuminate\Support\Facades\Schema;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateStoredEventsTable extends Migration
+return new class extends Migration
 {
-    public function up()
+    public function up(): void
     {
         Schema::create('stored_events', function (Blueprint $table) {
             $table->bigIncrements('id');
@@ -23,4 +23,4 @@ class CreateStoredEventsTable extends Migration
             $table->unique(['aggregate_uuid', 'aggregate_version']);
         });
     }
-}
+};

--- a/database/migrations/create_stored_events_table.php.stub
+++ b/database/migrations/create_stored_events_table.php.stub
@@ -9,7 +9,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::create('stored_events', function (Blueprint $table) {
-            $table->bigIncrements('id');
+            $table->id();
             $table->uuid('aggregate_uuid')->nullable();
             $table->unsignedBigInteger('aggregate_version')->nullable();
             $table->unsignedTinyInteger('event_version')->default(1);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -51,12 +51,12 @@ abstract class TestCase extends Orchestra
         });
 
         Schema::dropIfExists('stored_events');
-        include_once __DIR__.'/../database/migrations/create_stored_events_table.php.stub';
-        (new CreateStoredEventsTable())->up();
+        $createStoredEventsTable = require __DIR__.'/../database/migrations/create_stored_events_table.php.stub';
+        $createStoredEventsTable->up();
 
         Schema::dropIfExists('snapshots');
-        include_once __DIR__.'/../database/migrations/create_snapshots_table.php.stub';
-        (new CreateSnapshotsTable())->up();
+        $createSnapshotsTable = require __DIR__.'/../database/migrations/create_snapshots_table.php.stub';
+        $createSnapshotsTable->up();
 
         Schema::dropIfExists('other_stored_events');
         if ($this->dbDriver() === 'mysql') {


### PR DESCRIPTION
Since minimum Laravel is v9, we can enforce to use closure migration