### PR TITLE
Docs: createdAt() method is camel case

### DIFF
--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -79,7 +79,7 @@ When using models with timestamps, it is important to keep in mind that the proj
 
 ```php
 public function onAccountCreated(AccountCreated $event) {
-        Account::create(array_merge($event->accountAttributes, ['created_at' => $event->created_at(), 'updated_at' => $event->created_at()]));
+        Account::create(array_merge($event->accountAttributes, ['created_at' => $event->createdAt(), 'updated_at' => $event->createdAt()]));
 }
 ```
 


### PR DESCRIPTION
This simply fixes a typo. The `createdAt()` method on `ShouldBeStored` is actually `camel case` and not `snake case` like the column name.