### PR TITLE
Do not assert events given to FakeAggregateRoot as recorded

### DIFF
--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -56,7 +56,7 @@ class FakeAggregateRoot
 
     public function assertNothingRecorded(): self
     {
-        Assert::assertCount(0, $this->aggregateRoot->getRecordedEvents());
+        Assert::assertCount(0, $this->getRecordedEventsAfterGiven());
 
         return $this;
     }
@@ -85,7 +85,7 @@ class FakeAggregateRoot
 
     public function assertNotRecorded($unexpectedEventClasses): self
     {
-        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->aggregateRoot->getRecordedEvents());
+        $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->getRecordedEventsAfterGiven());
 
         $unexpectedEventClasses = Arr::wrap($unexpectedEventClasses);
 
@@ -173,6 +173,11 @@ class FakeAggregateRoot
             unset($metaData[MetaData::AGGREGATE_ROOT_VERSION]);
 
             return $eventWithoutUuid->setMetaData($metaData);
-        }, array_slice($this->aggregateRoot->getRecordedEvents(), $this->givenEventsCount));
+        }, $this->getRecordedEventsAfterGiven());
+    }
+
+    private function getRecordedEventsAfterGiven(): array
+    {
+        return array_slice($this->aggregateRoot->getRecordedEvents(), $this->givenEventsCount);
     }
 }

--- a/tests/FakeAggregateRootTest.php
+++ b/tests/FakeAggregateRootTest.php
@@ -14,6 +14,33 @@ class FakeAggregateRootTest extends TestCase
     }
 
     /** @test */
+    public function it_ignores_given_events_in_assert_nothing_recorded()
+    {
+        DummyAggregateRoot::fake()
+            ->given([new DummyEvent(123)])
+            ->assertNothingRecorded();
+    }
+
+    /** @test */
+    public function it_ignores_given_events_in_assert_recorded()
+    {
+        DummyAggregateRoot::fake()
+            ->given([new DummyEvent(1)])
+            ->when(function (DummyAggregateRoot $dummyAggregateRoot) {
+                $dummyAggregateRoot->dummy();
+            })
+            ->assertRecorded([new DummyEvent(2)]);
+    }
+
+    /** @test */
+    public function it_ignores_given_events_in_assert_not_recorded()
+    {
+        DummyAggregateRoot::fake()
+            ->given([new DummyEvent(123)])
+            ->assertNotRecorded(DummyEvent::class);
+    }
+
+    /** @test */
     public function it_can_retrieve_an_aggregate_for_a_given_uuid()
     {
         $fakeUuid = 'fake-uuid';


### PR DESCRIPTION
Hi there! I'm in the process of upgrading an application that ran on v4 this package. The test suite depends quite heavily on `FakeAggregateRoot` to assert that events get recorded or not.

Jumping major versions from v5 to v6 broke a bunch of these tests, and I suspect it happened when [v6.0.1](https://github.com/spatie/laravel-event-sourcing/releases/tag/6.0.1) no longer persisted the aggregate root in `FakeAggregateRoot::given()`.

Inadvertently, a side-effect of persisting was also removed: the recorded events on the AggregateRoot would be cleared. That effectively excluded given events from assertions about recorded events. This was compensated for in `FakeAggregateRoot::getRecordedEventsWithoutUuid()`, but not in other methods that accessed recorded events on the aggregate root.

This behavior is also implied in the documentation on testing aggregates (https://github.com/spatie/laravel-event-sourcing/blob/7.2.0/docs/using-aggregates/testing-aggregates.md). Note how the given events include `MoneySubtracted`, and later it is asserted that `MoneySubtracted` was not recorded.
```php
/** @test */
public function it_will_not_make_subtractions_that_would_go_below_the_account_limit()
{
    AccountAggregateRoot::fake()
        ->given([new AccountCreated('Luke'), new MoneySubtracted(4999)])
        ->when(function (AccountAggregate $accountAggregate) {
            $accountAggregate->subtractMoney(2);
        })
        ->assertRecorded(new AccountLimitHit(2))
        ->assertNotRecorded(MoneySubtracted::class);
}
 ```

This PR restores the behavior of `FakeAggregateRoot::assertNotRecorded` and `FakeAggregateRoot::assertNothingRecorded()`, where given events would be ignored when asserting recorded events.
