### PR TITLE
Fix method annotations in Projection class

### DIFF
--- a/src/Projections/Projection.php
+++ b/src/Projections/Projection.php
@@ -5,8 +5,8 @@ namespace Spatie\EventSourcing\Projections;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @method static create(array $parameters = [])
- * @method static find(string $uuid): static|null
+ * @method static static create(array $parameters = [])
+ * @method static static|null find(string $uuid)
  */
 abstract class Projection extends Model
 {


### PR DESCRIPTION
[According to phpDocumentor docs](https://docs.phpdoc.org/3.0/guide/references/phpdoc/tags/method.html) correct placement of return type is before method name, like in C. Checked in PhpStorm - it didn't worked with trailing return type.
Also, both `EloquentStoredEventQueryBuilder` and `EloquentStoredEvent` have correct return type placement in their magic method declarations.