### PR TITLE
Exclude `tap` from possible handlers

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -72,7 +72,7 @@ abstract class AggregateRoot
         if ($handler = Handlers::new($this)
             ->public()
             ->protected()
-            ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply']))
+            ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply', 'tap']))
             ->accepts($command)
             ->first()
         ) {
@@ -85,7 +85,7 @@ abstract class AggregateRoot
             $handler = Handlers::new($partial)
                 ->public()
                 ->protected()
-                ->reject(fn (Method $method) => in_array($method->getName(), ['recordThat', 'apply']))
+                ->reject(fn (Method $method) => in_array($method->getName(), ['recordThat', 'apply', 'tap']))
                 ->accepts($command)
                 ->first();
 
@@ -255,7 +255,7 @@ abstract class AggregateRoot
         Handlers::new($this)
             ->public()
             ->protected()
-            ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply']))
+            ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply', 'tap']))
             ->accepts($event)
             ->all()
             ->each(fn (Method $method) => $this->{$method->getName()}($event));


### PR DESCRIPTION
In a project I'm working on we've added `Illuminate\Support\Traits\Tappable` to our `AggregateRoot`. However, since upgrading to v7, the `Handlers` utility finds `tap` as an acceptable method for applying events.

The type of the `$callable` parameter of `tap` is resolved as `mixed` as it is only typed with an annotation.

In this case this is unexpected behaviour as a `StoredEvent` is never callable. This PR adds an exclusion of `tap` to the resolving of handlers for commands and events.