### PR TITLE
Update event-sourcing:replay command to work with just one aggregate uuid

### DIFF
--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -35,6 +35,12 @@ If you are [using your own event storage model](/laravel-event-sourcing/v4/advan
 php artisan event-sourcing:replay --stored-event-model=App\\Models\\AccountStoredEvent
  ```
 
+If you only want to reply events for a specific aggregate only, you can use the `--aggregate-uuid` option.
+
+```bash
+php artisan event-sourcing:replay --aggregate-uuid=12345678-1234-1234-1234-1234567890ab
+ ```
+
 ## Detecting event replays
 
 If your projector contains an `onStartingEventReplay` method, we'll call it right before the first event is replayed.

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -12,7 +12,8 @@ class ReplayCommand extends Command
 {
     protected $signature = 'event-sourcing:replay {projector?*}
                             {--from=0 : Replay events starting from this event number}
-                            {--stored-event-model= : Replay events from this store}';
+                            {--stored-event-model= : Replay events from this store}
+                            {--uuid= : Replay events for this uuid only}';
 
     protected $description = 'Replay stored events';
 
@@ -30,7 +31,7 @@ class ReplayCommand extends Command
             return;
         }
 
-        $this->replay($projectors, (int)$this->option('from'));
+        $this->replay($projectors, (int)$this->option('from'), $this->option('uuid'));
     }
 
     public function selectProjectors(array $projectorClassNames): ?Collection
@@ -54,7 +55,7 @@ class ReplayCommand extends Command
             });
     }
 
-    public function replay(Collection $projectors, int $startingFrom): void
+    public function replay(Collection $projectors, int $startingFrom, ?string $uuid = null): void
     {
         $repository = app(StoredEventRepository::class);
         $replayCount = $repository->countAllStartingFrom($startingFrom);
@@ -72,7 +73,7 @@ class ReplayCommand extends Command
             $bar->advance();
         };
 
-        $this->projectionist->replay($projectors, $startingFrom, $onEventReplayed);
+        $this->projectionist->replay($projectors, $startingFrom, $onEventReplayed, $uuid);
 
         $bar->finish();
 

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -58,7 +58,7 @@ class ReplayCommand extends Command
     public function replay(Collection $projectors, int $startingFrom, ?string $uuid = null): void
     {
         $repository = app(StoredEventRepository::class);
-        $replayCount = $repository->countAllStartingFrom($startingFrom);
+        $replayCount = $repository->countAllStartingFrom($startingFrom, $uuid);
 
         if ($replayCount === 0) {
             $this->warn('There are no events to replay');

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -13,7 +13,7 @@ class ReplayCommand extends Command
     protected $signature = 'event-sourcing:replay {projector?*}
                             {--from=0 : Replay events starting from this event number}
                             {--stored-event-model= : Replay events from this store}
-                            {--uuid= : Replay events for this uuid only}';
+                            {--aggregate-uuid= : Replay events for this aggregate only}';
 
     protected $description = 'Replay stored events';
 
@@ -31,7 +31,7 @@ class ReplayCommand extends Command
             return;
         }
 
-        $this->replay($projectors, (int)$this->option('from'), $this->option('uuid'));
+        $this->replay($projectors, (int)$this->option('from'), $this->option('aggregate-uuid'));
     }
 
     public function selectProjectors(array $projectorClassNames): ?Collection
@@ -55,10 +55,10 @@ class ReplayCommand extends Command
             });
     }
 
-    public function replay(Collection $projectors, int $startingFrom, ?string $uuid = null): void
+    public function replay(Collection $projectors, int $startingFrom, ?string $aggregateUuid = null): void
     {
         $repository = app(StoredEventRepository::class);
-        $replayCount = $repository->countAllStartingFrom($startingFrom, $uuid);
+        $replayCount = $repository->countAllStartingFrom($startingFrom, $aggregateUuid);
 
         if ($replayCount === 0) {
             $this->warn('There are no events to replay');
@@ -73,7 +73,7 @@ class ReplayCommand extends Command
             $bar->advance();
         };
 
-        $this->projectionist->replay($projectors, $startingFrom, $onEventReplayed, $uuid);
+        $this->projectionist->replay($projectors, $startingFrom, $onEventReplayed, $aggregateUuid);
 
         $bar->finish();
 

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -320,7 +320,7 @@ class Projectionist
         Collection $projectors,
         int $startingFromEventId = 0,
         callable $onEventReplayed = null,
-        ?string $uuid = null
+        ?string $aggregateUuid = null
     ): void {
         $projectors = new EventHandlerCollection($projectors);
 
@@ -339,7 +339,7 @@ class Projectionist
         $projectors->call('onStartingEventReplay');
 
         app(StoredEventRepository::class)
-            ->retrieveAllStartingFrom($startingFromEventId, $uuid)
+            ->retrieveAllStartingFrom($startingFromEventId, $aggregateUuid)
             ->each(function (StoredEvent $storedEvent) use ($projectors, $onEventReplayed) {
                 $this->applyStoredEventToProjectors(
                     $storedEvent,

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -319,7 +319,8 @@ class Projectionist
     public function replay(
         Collection $projectors,
         int $startingFromEventId = 0,
-        callable $onEventReplayed = null
+        callable $onEventReplayed = null,
+        ?string $uuid = null
     ): void {
         $projectors = new EventHandlerCollection($projectors);
 
@@ -338,7 +339,7 @@ class Projectionist
         $projectors->call('onStartingEventReplay');
 
         app(StoredEventRepository::class)
-            ->retrieveAllStartingFrom($startingFromEventId)
+            ->retrieveAllStartingFrom($startingFromEventId, $uuid)
             ->each(function (StoredEvent $storedEvent) use ($projectors, $onEventReplayed) {
                 $this->applyStoredEventToProjectors(
                     $storedEvent,

--- a/tests/Console/ReplayCommandTest.php
+++ b/tests/Console/ReplayCommandTest.php
@@ -156,7 +156,7 @@ class ReplayCommandTest extends TestCase
 
         $this->artisan('event-sourcing:replay', [
                 'projector' => [AccountProjector::class],
-                '--uuid' => $uuid1
+                '--aggregate-uuid' => $uuid1
             ])
             ->expectsOutput('Replaying 1 events...')
             ->assertExitCode(0);

--- a/tests/Console/ReplayCommandTest.php
+++ b/tests/Console/ReplayCommandTest.php
@@ -1,16 +1,19 @@
 <?php
 
-namespace Spatie\EventSourcing\Console;
+namespace Spatie\EventSourcing\Tests\Console;
 
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Mail;
+use Ramsey\Uuid\Uuid;
 use Spatie\EventSourcing\Events\FinishedEventReplay;
 use Spatie\EventSourcing\Events\StartingEventReplay;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
 use Spatie\EventSourcing\Tests\TestCase;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithStoredEventRepositorySpecified;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Projectors\AccountProjector;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneySubtractedEvent;
 use Spatie\EventSourcing\Tests\TestClasses\Mailables\AccountBroke;
@@ -129,6 +132,33 @@ class ReplayCommandTest extends TestCase
 
         $this->artisan('event-sourcing:replay', ['--stored-event-model' => OtherEloquentStoredEvent::class])
             ->expectsOutput('Replaying 5 events...')
+            ->assertExitCode(0);
+    }
+
+    /** @test */
+    public function it_will_replay_events_for_a_specific_aggregate_root_uuid()
+    {
+        EloquentStoredEvent::truncate();
+
+        $uuid1 = Uuid::uuid4();
+        $account1 = AccountAggregateRoot::retrieve($uuid1);
+        $account1->addMoney(1000);
+        $account1->persist();
+
+        $uuid2 = Uuid::uuid4();
+        $account2 = AccountAggregateRoot::retrieve($uuid2);
+        $account2->addMoney(1000);
+        $account2->persist();
+
+        $projector = app(AccountProjector::class);
+
+        Projectionist::addProjector($projector);
+
+        $this->artisan('event-sourcing:replay', [
+                'projector' => [AccountProjector::class],
+                '--uuid' => $uuid1
+            ])
+            ->expectsOutput('Replaying 1 events...')
             ->assertExitCode(0);
     }
 }


### PR DESCRIPTION
This MR adds an `--aggregate-uuid=` option to the `event-sourcing:replay` command. When used, the replay command will only replay events for that specific aggregate root uuid.

For context, we use this in order to speed up the replaying process, by running multiple jobs in parallel, each job replaying one specific aggregate uuid.