### PR TITLE
Support weight property to event handlers

### DIFF
--- a/docs/using-projectors/making-sure-events-get-handled-in-the-right-order.md
+++ b/docs/using-projectors/making-sure-events-get-handled-in-the-right-order.md
@@ -15,6 +15,25 @@ You can set the name of the queue connection in the `queue` key of the `event-so
 
 In a local environment, where events have a very low chance of getting fired concurrently, it's probably ok to just use the `sync` driver.
 
+## Tweaking projector order
+
+You can add a weight property to a projector to tweak the order projectors are run in. Projectors with a lower weight run first. When no explicit weight is provided, the weight is considered `0`.
+
+```php
+namespace App\Projectors;
+
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+
+class MyProjector extends Projector
+{
+    public int $weight = 5;
+    
+    //
+}
+```
+
+Note that providing a weight on a queued projector won't guarentee execution order.
+
 ## Want to know more?
 
 We discuss projections and complex patterns such as CQRS in depth in our [Event Sourcing in Laravel](https://event-sourcing-laravel.com/) course. In practice, you want to check out these chapters:

--- a/docs/using-reactors/creating-and-configuring-reactors.md
+++ b/docs/using-reactors/creating-and-configuring-reactors.md
@@ -183,6 +183,21 @@ class SendMoneyAddedMail
 }
 ```
 
+## Tweaking reactor order
+
+You can add a weight property to a reactor to tweak the order reactors are run in. Reactors with a lower weight run first. When no explicit weight is provided, the weight is considered `0`.
+
+```php
+namespace App\Reactors;
+
+class MyReactor
+{
+    public int $weight = 5;
+}
+```
+
+Note that providing a weight on a queued reactor won't guarentee execution order.
+
 ## Want to know more?
 
 Reactors and process managers (which are built on top of the core reactor principle) are thoroughly discussed in [Event Sourcing in Laravel](https://event-sourcing-laravel.com/). More specifically, you want to read these chapters:

--- a/src/EventHandlers/EventHandlerCollection.php
+++ b/src/EventHandlers/EventHandlerCollection.php
@@ -53,15 +53,19 @@ class EventHandlerCollection extends Collection
 
     public function syncEventHandlers(): self
     {
-        return $this->reject(
-            fn (EventHandler $eventHandler) => $eventHandler instanceof ShouldQueue
-        );
+        return $this
+            ->reject(
+                fn (EventHandler $eventHandler) => $eventHandler instanceof ShouldQueue
+            )
+            ->sortBy('weight');
     }
 
     public function asyncEventHandlers(): self
     {
-        return $this->filter(
-            fn (EventHandler $eventHandler) => $eventHandler instanceof ShouldQueue
-        );
+        return $this
+            ->filter(
+                fn (EventHandler $eventHandler) => $eventHandler instanceof ShouldQueue
+            )
+            ->sortBy('weight');
     }
 }

--- a/src/EventHandlers/EventHandlerCollection.php
+++ b/src/EventHandlers/EventHandlerCollection.php
@@ -57,7 +57,9 @@ class EventHandlerCollection extends Collection
             ->reject(
                 fn (EventHandler $eventHandler) => $eventHandler instanceof ShouldQueue
             )
-            ->sortBy('weight');
+            ->sortBy(
+                fn (EventHandler $eventHandler) => $eventHandler->weight ?? 0
+            );
     }
 
     public function asyncEventHandlers(): self
@@ -66,6 +68,8 @@ class EventHandlerCollection extends Collection
             ->filter(
                 fn (EventHandler $eventHandler) => $eventHandler instanceof ShouldQueue
             )
-            ->sortBy('weight');
+            ->sortBy(
+                fn (EventHandler $eventHandler) => $eventHandler->weight ?? 0
+            );
     }
 }

--- a/src/EventHandlers/EventHandlerCollection.php
+++ b/src/EventHandlers/EventHandlerCollection.php
@@ -53,7 +53,7 @@ class EventHandlerCollection extends Collection
 
     public function syncEventHandlers(): self
     {
-        return $this ->reject(
+        return $this->reject(
             fn (EventHandler $eventHandler) => $eventHandler instanceof ShouldQueue
         );
     }

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -66,15 +66,9 @@ class EventSerializerTest extends TestCase
 
         $array = json_decode($json, true);
 
-        $this->assertEquals([
-            'account' => [
-                'class' => get_class($account),
-                'id' => 1,
-                'relations' => [],
-                'connection' => $this->dbDriver(),
-            ],
-            'amount' => 1234,
-        ], $array);
+        $this->assertEquals(get_class($account), $array['account']['class'] ?? null);
+        $this->assertEquals(1, $array['account']['id'] ?? null);
+        $this->assertEquals(1234, $array['amount'] ?? null);
     }
 
     /** @test */

--- a/tests/ProjectionistTest.php
+++ b/tests/ProjectionistTest.php
@@ -15,8 +15,8 @@ use Spatie\EventSourcing\Tests\TestClasses\Projectors\FakeMoneyAddedCountProject
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\MoneyAddedCountProjector;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorThatThrowsAnException;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithHighWeight;
-use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithoutWeight;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithLowWeight;
+use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithoutWeight;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\QueuedProjector;
 use Spatie\EventSourcing\Tests\TestClasses\ProjectorWithWeightTestHelper;
 use Spatie\EventSourcing\Tests\TestClasses\Reactors\BrokeReactor;

--- a/tests/ProjectionistTest.php
+++ b/tests/ProjectionistTest.php
@@ -15,8 +15,8 @@ use Spatie\EventSourcing\Tests\TestClasses\Projectors\FakeMoneyAddedCountProject
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\MoneyAddedCountProjector;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorThatThrowsAnException;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithHighWeight;
-use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithNegativeWeight;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithLowWeight;
+use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithNegativeWeight;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithoutWeight;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\QueuedProjector;
 use Spatie\EventSourcing\Tests\TestClasses\ProjectorWithWeightTestHelper;

--- a/tests/ProjectionistTest.php
+++ b/tests/ProjectionistTest.php
@@ -15,6 +15,7 @@ use Spatie\EventSourcing\Tests\TestClasses\Projectors\FakeMoneyAddedCountProject
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\MoneyAddedCountProjector;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorThatThrowsAnException;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithHighWeight;
+use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithNegativeWeight;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithLowWeight;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\ProjectorWithoutWeight;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\QueuedProjector;
@@ -87,11 +88,13 @@ class ProjectionistTest extends TestCase
 
         Projectionist::addProjector(ProjectorWithHighWeight::class);
         Projectionist::addProjector(ProjectorWithoutWeight::class);
+        Projectionist::addProjector(ProjectorWithNegativeWeight::class);
         Projectionist::addProjector(ProjectorWithLowWeight::class);
 
         event(new MoneyAddedEvent($this->account, 1000));
 
         $this->assertSame([
+            ProjectorWithNegativeWeight::class,
             ProjectorWithoutWeight::class,
             ProjectorWithLowWeight::class,
             ProjectorWithHighWeight::class,

--- a/tests/TestClasses/ProjectorWithWeightTestHelper.php
+++ b/tests/TestClasses/ProjectorWithWeightTestHelper.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses;
+
+class ProjectorWithWeightTestHelper
+{
+    public array $calledBy = [];
+
+    public function calledBy(string $className): void
+    {
+        $this->calledBy[] = $className;
+    }
+}

--- a/tests/TestClasses/Projectors/ProjectorWithHighWeight.php
+++ b/tests/TestClasses/Projectors/ProjectorWithHighWeight.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Projectors;
+
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
+use Spatie\EventSourcing\Tests\TestClasses\ProjectorWithWeightTestHelper;
+
+class ProjectorWithHighWeight extends Projector
+{
+    public int $weight = 5;
+
+    public function __construct(
+        private ProjectorWithWeightTestHelper $projectorWithWeightTestHelper,
+    ) {
+    }
+
+    public function onMoneyAdded(MoneyAddedEvent $event): void
+    {
+        $this->projectorWithWeightTestHelper->calledBy(static::class);
+    }
+}

--- a/tests/TestClasses/Projectors/ProjectorWithLowWeight.php
+++ b/tests/TestClasses/Projectors/ProjectorWithLowWeight.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Projectors;
+
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
+use Spatie\EventSourcing\Tests\TestClasses\ProjectorWithWeightTestHelper;
+
+class ProjectorWithLowWeight extends Projector
+{
+    public int $weight = 1;
+
+    public function __construct(
+        private ProjectorWithWeightTestHelper $projectorWithWeightTestHelper,
+    ) {
+    }
+
+    public function onMoneyAdded(MoneyAddedEvent $event): void
+    {
+        $this->projectorWithWeightTestHelper->calledBy(static::class);
+    }
+}

--- a/tests/TestClasses/Projectors/ProjectorWithNegativeWeight.php
+++ b/tests/TestClasses/Projectors/ProjectorWithNegativeWeight.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Projectors;
+
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
+use Spatie\EventSourcing\Tests\TestClasses\ProjectorWithWeightTestHelper;
+
+class ProjectorWithNegativeWeight extends Projector
+{
+    public int $weight = -5;
+
+    public function __construct(
+        private ProjectorWithWeightTestHelper $projectorWithWeightTestHelper,
+    ) {
+    }
+
+    public function onMoneyAdded(MoneyAddedEvent $event): void
+    {
+        $this->projectorWithWeightTestHelper->calledBy(static::class);
+    }
+}

--- a/tests/TestClasses/Projectors/ProjectorWithoutWeight.php
+++ b/tests/TestClasses/Projectors/ProjectorWithoutWeight.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Projectors;
+
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
+use Spatie\EventSourcing\Tests\TestClasses\ProjectorWithWeightTestHelper;
+
+class ProjectorWithoutWeight extends Projector
+{
+    public function __construct(
+        private ProjectorWithWeightTestHelper $projectorWithWeightTestHelper,
+    ) {
+    }
+
+    public function onMoneyAdded(MoneyAddedEvent $event): void
+    {
+        $this->projectorWithWeightTestHelper->calledBy(static::class);
+    }
+}


### PR DESCRIPTION
This is a lightweight (🥁) solution to allow package users to tweak the order projectors and reactors will run.