### PR TITLE
Use the snapshot with the highest ID

### DIFF
--- a/src/Snapshots/EloquentSnapshotRepository.php
+++ b/src/Snapshots/EloquentSnapshotRepository.php
@@ -22,7 +22,7 @@ class EloquentSnapshotRepository implements SnapshotRepository
         /** @var \Illuminate\Database\Query\Builder $query */
         $query = $this->snapshotModel::query();
 
-        if ($snapshot = $query->latest()->uuid($aggregateUuid)->first()) {
+        if ($snapshot = $query->orderByDesc('id')->uuid($aggregateUuid)->first()) {
             return $snapshot->toSnapshot();
         }
 


### PR DESCRIPTION
If two snapshots are created within the same second, the retrieval method will fetch the first one, not the last one.

Any remaining events are still applied afterwards so the aggregate is consistent, but it means the snapshot effect didn't completely encapsulate the state at the time as expected.

The test confirms that no events needed to be applied after the snapshot is retrieved.