### PR TITLE
Fixes bug with retrieving last event

### DIFF
--- a/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
+++ b/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
@@ -59,6 +59,7 @@ class EloquentStoredEventQueryBuilder extends Builder
                 fn (self $query) => $query->whereEvent(...$eventClasses)
             )
             ->orderByDesc('created_at')
+            ->orderByDesc('id')
             ->first();
     }
 }

--- a/tests/Models/EloquentStoredEventQueryBuilderTest.php
+++ b/tests/Models/EloquentStoredEventQueryBuilderTest.php
@@ -104,3 +104,17 @@ it('retrieves last event of multiple types', function () {
     assertInstanceOf(EventWithCarbon::class, $storedEvent);
     assertEquals($date, $storedEvent->value);
 });
+
+it('retrieves last event of type when two were created at the same time', function () {
+    $this->freezeTime();
+
+    event(new MoneyAdded(50));
+    event(new MoneyAdded(10));
+
+    $event = EloquentStoredEvent::query()->lastEvent(MoneyAdded::class);
+    /** @var MoneyAdded $storedEvent */
+    $storedEvent = $event->toStoredEvent()->event;
+
+    assertInstanceOf(MoneyAdded::class, $storedEvent);
+    assertEquals(10, $storedEvent->amount);
+});

--- a/tests/Models/EloquentStoredEventQueryBuilderTest.php
+++ b/tests/Models/EloquentStoredEventQueryBuilderTest.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventSourcing\Tests\Models;
 
+use Carbon\Carbon;
 use Illuminate\Support\InteractsWithTime;
 
 use function PHPUnit\Framework\assertEquals;
@@ -106,7 +107,7 @@ it('retrieves last event of multiple types', function () {
 });
 
 it('retrieves last event of type when two were created at the same time', function () {
-    $this->freezeTime();
+    Carbon::setTestNow();
 
     event(new MoneyAdded(50));
     event(new MoneyAdded(10));


### PR DESCRIPTION
This pull request fixes a bug with retrieving the last event when two events exist with the same timestamp. We ran into this issue when two events occurred at the exact same time and the event query failed to pull the proper information in.