### PR TITLE
Proposal: Aliasing events using EventAlias attribute

### DIFF
--- a/src/Attributes/EventAlias.php
+++ b/src/Attributes/EventAlias.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\EventSourcing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class EventAlias
+{
+    public function __construct(
+        public string $alias,
+    ) {
+    }
+}

--- a/src/Dictionary.php
+++ b/src/Dictionary.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Spatie\EventSourcing;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\LazyCollection;
+use ReflectionClass;
+use Spatie\EventSourcing\Attributes\EventAlias;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class Dictionary
+{
+    public function getAliasDictionary() : Collection
+    {
+        /** @var LazyCollection<string,string> $aliasedClasses */
+        $aliasedClasses = LazyCollection::make(function () {
+            foreach (get_declared_classes() as $declaredClass) {
+                if (is_subclass_of($declaredClass, ShouldBeStored::class)) {
+                    yield $declaredClass;
+                }
+            }
+        })
+            ->map(fn (string $eventClass) => new ReflectionClass($eventClass))
+            ->reject(fn (ReflectionClass $reflection) => empty($reflection->getAttributes(EventAlias::class)))
+            ->mapWithKeys(function (ReflectionClass $reflection) {
+                /** @var ReflectionClass<EventAlias> $attribute */
+                $attribute = $reflection->getAttributes(EventAlias::class)[0];
+
+                return [$reflection->getName() => ($attribute->newInstance())->alias];
+            });
+
+        return collect(array_flip(config('event-sourcing.event_class_map', [])))
+            ->merge($aliasedClasses->toArray())
+            ->flip();
+    }
+
+    public function getAliasFromClass(string $class): string|false
+    {
+        return $this->getAliasDictionary()->search($class, true);
+    }
+
+    public function getClassFromAlias(string $alias): string|false
+    {
+        return $this->getAliasDictionary()->get($alias, false);
+    }
+}

--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -65,6 +65,12 @@ class EventSourcingServiceProvider extends PackageServiceProvider
 
         $this->app->alias(Projectionist::class, 'event-sourcing');
 
+        $this->app->singleton(Dictionary::class, function () {
+            return new Dictionary();
+        });
+
+        $this->app->alias(Dictionary::class, 'event-sourcing-alias-dictionary');
+
         $this->app->singleton(StoredEventRepository::class, config('event-sourcing.stored_event_repository'));
 
         $this->app->singleton(EventSubscriber::class, fn () => new EventSubscriber(config('event-sourcing.stored_event_repository')));

--- a/src/Facades/Dictionary.php
+++ b/src/Facades/Dictionary.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\EventSourcing\Facades;
+
+use Illuminate\Support\Facades\Facade;
+
+class Dictionary extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'event-sourcing-alias-dictionary';
+    }
+}

--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -4,9 +4,10 @@ namespace Spatie\EventSourcing\StoredEvents;
 
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
-use Illuminate\Support\Arr;
+use Illuminate\Support\LazyCollection;
 use ReflectionClass;
 use ReflectionException;
+use Spatie\EventSourcing\Attributes\EventAlias;
 use Spatie\EventSourcing\Attributes\EventSerializer as EventSerializerAttribute;
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\Facades\Projectionist;
@@ -149,17 +150,46 @@ class StoredEvent implements Arrayable
 
     protected static function getActualClassForEvent(string $class): string
     {
-        return Arr::get(config('event-sourcing.event_class_map', []), $class, $class);
+        /** @var LazyCollection<string,string> $aliasedClasses */
+        $aliasedClasses = LazyCollection::make(function () {
+            foreach (get_declared_classes() as $declaredClass) {
+                if (is_subclass_of($declaredClass, ShouldBeStored::class)) {
+                    yield $declaredClass;
+                }
+            }
+        })
+            ->map(fn (string $eventClass) => new ReflectionClass($eventClass))
+            ->reject(fn (ReflectionClass $reflection) => empty($reflection->getAttributes(EventAlias::class)))
+            ->mapWithKeys(function (ReflectionClass $reflection) {
+                /** @var ReflectionClass<EventAlias> $attribute */
+                $attribute = $reflection->getAttributes(EventAlias::class)[0];
+
+                return [($attribute->newInstance())->alias => $reflection->getName()];
+            });
+
+        return collect(config('event-sourcing.event_class_map', []))
+            ->merge($aliasedClasses->toArray())
+            ->get($class, $class);
     }
 
     protected static function getEventClass(string $class): string
     {
-        $map = config('event-sourcing.event_class_map', []);
+        $alias = collect(config('event-sourcing.event_class_map', []))
+            ->flip() // a given event should be aliased only once, so let's flip the collection to make class name the key
+            ->merge(
+            // merge alias from class' EventAlias attribute, if present
+                collect([new ReflectionClass($class)])
+                    ->reject(fn (ReflectionClass $reflection) => empty($reflection->getAttributes(EventAlias::class)))
+                    ->mapWithKeys(function (ReflectionClass $reflection) {
+                        /** @var ReflectionClass<EventAlias> $attribute */
+                        $attribute = $reflection->getAttributes(EventAlias::class)[0];
 
-        if (! empty($map) && in_array($class, $map)) {
-            return array_search($class, $map, true);
-        }
+                        return [$reflection->getName() => ($attribute->newInstance())->alias];
+                    })
+            )
+            ->flip() // flip it back so the alias is the key
+            ->search($class, true);
 
-        return $class;
+        return $alias ?: $class;
     }
 }

--- a/tests/TestClasses/Events/EventWithAlias.php
+++ b/tests/TestClasses/Events/EventWithAlias.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Events;
+
+use Spatie\EventSourcing\Attributes\EventAlias;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+#[EventAlias('event_with_alias')]
+class EventWithAlias extends ShouldBeStored
+{
+}


### PR DESCRIPTION
Hey guys,

I've been using the package in a project and we're basically aliasing all our events in the config file. On top of the `event_class_map` having 150+ lines (and growing) at this point, I have always the concern someone might forget to add an alias there when introducing a new event. It also adds some cognitive load to remember we need to go in the event-sourcing.php file to check what the alias for a certain event is. So, I was thinking why not bring that closer to the source, the event class itself? That way if we open an event class it's already in our faces the fact it has an alias or not. Since we already have a few attributes (version and serializer) we can use in events, I thought it might be a good idea to add a new EventAlias attribute for this purpose.

So your event alias definition would look like this:

```php
#[EventAlias('money_added')]
class MoneyAdded extends ShouldBeStored
{
}
```

Again, a pro with using this approach is we've that information right there with the event definition, so no need to navigate to another file to discover it. Maybe a con is there could be more than one event with the same alias value, although this could also happen in the config approach by declaring the same key in array.

I've done a "quick and dirty" implementation just to get a feeling if the feature would be useful to more people. There's probably a performance concern to be revisited in `StoredEvent::getActualClassForEvent` where we need to find the event class from the alias value, which is not as straightforward as just looking it up in the config map. I've basically got all declared classes and filtered the ones which extend StoredEvent, then filtering the ones that have the attribute, just to get something working.

The implementaion is backwards compatible, so the config map still works, and if a EventAlias is available it takes precedence over the mapped value.

Anyway, thoughts?