### PR TITLE
Make projections trait based instead of class based

### DIFF
--- a/src/Projections/Concerns/Projectionable.php
+++ b/src/Projections/Concerns/Projectionable.php
@@ -1,0 +1,79 @@
+<?php
+
+namespace Spatie\EventSourcing\Projections\Concerns;
+
+use Spatie\EventSourcing\Projections\ProjectionObserver;
+
+trait Projectionable
+{
+    private bool $isWriteable = false;
+
+    protected static function boot(): void
+    {
+        parent::boot();
+
+        static::observe(ProjectionObserver::class);
+    }
+
+    public static function new(): static
+    {
+        return new static();
+    }
+
+    public function getKeyName()
+    {
+        return 'uuid';
+    }
+
+    public function getKeyType()
+    {
+        return 'string';
+    }
+
+    public function getIncrementing()
+    {
+        return false;
+    }
+
+    public function getRouteKeyName()
+    {
+        return 'uuid';
+    }
+
+    public function writeable(): static
+    {
+        $clone = clone $this;
+
+        $clone->isWriteable = true;
+
+        return $clone;
+    }
+
+    public function isWriteable(): bool
+    {
+        return $this->isWriteable;
+    }
+
+    public function refresh(): static
+    {
+        $this->isWriteable = false;
+
+        return parent::refresh();
+    }
+
+    public function fresh($with = []): ?static
+    {
+        $this->isWriteable = false;
+
+        return parent::fresh($with);
+    }
+
+    public function newInstance($attributes = [], $exists = false): static
+    {
+        $instance = parent::newInstance($attributes, $exists);
+
+        $instance->isWriteable = $this->isWriteable;
+
+        return $instance;
+    }
+}

--- a/src/Projections/Contracts/Writable.php
+++ b/src/Projections/Contracts/Writable.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\EventSourcing\Projections\Contracts;
+
+interface Writable
+{
+    /**
+     * Verify if the projection is writable
+     *
+     * @return boolean
+     */
+    public function isWriteable(): bool;
+}

--- a/src/Projections/Projection.php
+++ b/src/Projections/Projection.php
@@ -3,81 +3,14 @@
 namespace Spatie\EventSourcing\Projections;
 
 use Illuminate\Database\Eloquent\Model;
+use Spatie\EventSourcing\Projections\Concerns\Projectionable;
+use Spatie\EventSourcing\Projections\Contracts\Writable;
 
 /**
  * @method static static create(array $parameters = [])
  * @method static static|null find(string $uuid)
  */
-abstract class Projection extends Model
+abstract class Projection extends Model implements Writable
 {
-    private bool $isWriteable = false;
-
-    protected static function boot(): void
-    {
-        parent::boot();
-
-        static::observe(ProjectionObserver::class);
-    }
-
-    public static function new(): static
-    {
-        return new static();
-    }
-
-    public function getKeyName()
-    {
-        return 'uuid';
-    }
-
-    public function getKeyType()
-    {
-        return 'string';
-    }
-
-    public function getIncrementing()
-    {
-        return false;
-    }
-
-    public function getRouteKeyName()
-    {
-        return 'uuid';
-    }
-
-    public function writeable(): static
-    {
-        $clone = clone $this;
-
-        $clone->isWriteable = true;
-
-        return $clone;
-    }
-
-    public function isWriteable(): bool
-    {
-        return $this->isWriteable;
-    }
-
-    public function refresh(): static
-    {
-        $this->isWriteable = false;
-
-        return parent::refresh();
-    }
-
-    public function fresh($with = []): ?static
-    {
-        $this->isWriteable = false;
-
-        return parent::fresh($with);
-    }
-
-    public function newInstance($attributes = [], $exists = false): static
-    {
-        $instance = parent::newInstance($attributes, $exists);
-
-        $instance->isWriteable = $this->isWriteable;
-
-        return $instance;
-    }
+    use Projectionable;
 }

--- a/src/Projections/ProjectionObserver.php
+++ b/src/Projections/ProjectionObserver.php
@@ -2,11 +2,12 @@
 
 namespace Spatie\EventSourcing\Projections;
 
+use Spatie\EventSourcing\Projections\Contracts\Writable;
 use Spatie\EventSourcing\Projections\Exceptions\ReadonlyProjection;
 
 class ProjectionObserver
 {
-    public function updating(Projection $projection): void
+    public function updating(Writable $projection): void
     {
         if ($projection->isWriteable()) {
             return;
@@ -15,7 +16,7 @@ class ProjectionObserver
         $this->preventChanges($projection);
     }
 
-    public function creating(Projection $projection): void
+    public function creating(Writable $projection): void
     {
         if ($projection->isWriteable()) {
             return;
@@ -24,7 +25,7 @@ class ProjectionObserver
         $this->preventChanges($projection);
     }
 
-    public function saving(Projection $projection): void
+    public function saving(Writable $projection): void
     {
         if ($projection->isWriteable()) {
             return;
@@ -33,7 +34,7 @@ class ProjectionObserver
         $this->preventChanges($projection);
     }
 
-    public function deleting(Projection $projection): void
+    public function deleting(Writable $projection): void
     {
         if ($projection->isWriteable()) {
             return;
@@ -42,7 +43,7 @@ class ProjectionObserver
         $this->preventChanges($projection);
     }
 
-    private function preventChanges(Projection $projection): void
+    private function preventChanges(Writable $projection): void
     {
         throw ReadonlyProjection::new(get_class($projection));
     }


### PR DESCRIPTION
Hi,

if you use a code generator to build your base models, having projections based on a class makes it difficult to reuse the code.

This PR moves the projections' feature in a trait and an interface. Existing code will keep working. 

For the users who want to extends their models class into projections, they just need to add an interface and a trait:

```php
class UserProjection extends Model implements Writable
{
    use Projectionable;
    // ...
}
```


