### PR TITLE
Make commands Lazy to allow extending

### DIFF
--- a/src/Console/CacheEventHandlersCommand.php
+++ b/src/Console/CacheEventHandlersCommand.php
@@ -7,7 +7,9 @@ use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Collection;
 use Spatie\EventSourcing\EventHandlers\EventHandler;
 use Spatie\EventSourcing\Projectionist;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'event-sourcing:cache-event-handlers')]
 class CacheEventHandlersCommand extends Command
 {
     protected $signature = 'event-sourcing:cache-event-handlers';

--- a/src/Console/ClearCachedEventHandlersCommand.php
+++ b/src/Console/ClearCachedEventHandlersCommand.php
@@ -4,7 +4,9 @@ namespace Spatie\EventSourcing\Console;
 
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'event-sourcing:clear-event-handlers')]
 class ClearCachedEventHandlersCommand extends Command
 {
     protected $signature = 'event-sourcing:clear-event-handlers';

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -6,7 +6,9 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Spatie\EventSourcing\EventHandlers\EventHandler;
 use Spatie\EventSourcing\Projectionist;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'event-sourcing:list')]
 class ListCommand extends Command
 {
     protected $signature = 'event-sourcing:list';

--- a/src/Console/MakeAggregateCommand.php
+++ b/src/Console/MakeAggregateCommand.php
@@ -3,7 +3,9 @@
 namespace Spatie\EventSourcing\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'make:aggregate')]
 class MakeAggregateCommand extends GeneratorCommand
 {
     protected $name = 'make:aggregate';

--- a/src/Console/MakeProjectorCommand.php
+++ b/src/Console/MakeProjectorCommand.php
@@ -3,8 +3,10 @@
 namespace Spatie\EventSourcing\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputOption;
 
+#[AsCommand(name: 'make:projector')]
 class MakeProjectorCommand extends GeneratorCommand
 {
     protected $name = 'make:projector';

--- a/src/Console/MakeReactorCommand.php
+++ b/src/Console/MakeReactorCommand.php
@@ -3,7 +3,9 @@
 namespace Spatie\EventSourcing\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'make:reactor')]
 class MakeReactorCommand extends GeneratorCommand
 {
     protected $name = 'make:reactor';

--- a/src/Console/MakeStorableEventCommand.php
+++ b/src/Console/MakeStorableEventCommand.php
@@ -3,7 +3,9 @@
 namespace Spatie\EventSourcing\Console;
 
 use Illuminate\Console\GeneratorCommand;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'make:storable-event')]
 class MakeStorableEventCommand extends GeneratorCommand
 {
     protected $name = 'make:storable-event';

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -7,7 +7,9 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Spatie\EventSourcing\Projectionist;
 use Spatie\EventSourcing\StoredEvents\Repositories\StoredEventRepository;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'event-sourcing:replay')]
 class ReplayCommand extends Command
 {
     protected $signature = 'event-sourcing:replay {projector?*}


### PR DESCRIPTION
Hi,

this small pull makes all commands Lazy loaded to support overriding. This makes it similiar to Laravel commands. Commands can also be Lazy through `$defaultName` property, but since this syntax is deprecated I didn't add it.