### PR TITLE
Fix documentation version cross-linking to other versions for v7. #396

### DIFF
--- a/docs/advanced-usage/discovering-projectors-and-reactors.md
+++ b/docs/advanced-usage/discovering-projectors-and-reactors.md
@@ -7,7 +7,7 @@ By default the package will automatically discover all projectors and reactors a
 
 If you want to see a list of the discovered projectors and reactors perform the `event-sourcing:list` Artisan command. Here's how the output could look like:
 
-<img src="/docs/laravel-event-sourcing/v5/images/list.png" />
+<img src="/docs/laravel-event-sourcing/v7/images/list.png" />
 
 ## Caching discovered projectors and reactors
 

--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -3,11 +3,11 @@ title: Replaying events
 weight: 2
 ---
 
-All [events](/laravel-event-sourcing/v5/advanced-usage/preparing-events/) that implement `Spatie\EventSourcing\ShouldBeStored` will be [serialized](/laravel-event-sourcing/v5/advanced-usage/using-your-own-event-serializer) and stored in the `stored_events` table. After your app has been doing its work for a while the `stored_events` table will probably contain some events.
+All [events](/laravel-event-sourcing/v7/advanced-usage/preparing-events/) that implement `Spatie\EventSourcing\ShouldBeStored` will be [serialized](/laravel-event-sourcing/v7/advanced-usage/using-your-own-event-serializer) and stored in the `stored_events` table. After your app has been doing its work for a while the `stored_events` table will probably contain some events.
 
- When creating a new [projector](/laravel-event-sourcing/v5/using-projectors/writing-your-first-projector/) you'll want to feed all stored events to that new projector. We call this process replaying events.
+ When creating a new [projector](/laravel-event-sourcing/v7/using-projectors/writing-your-first-projector/) you'll want to feed all stored events to that new projector. We call this process replaying events.
 
- Events can be replayed to [all projectors that were added to the projectionist](/laravel-event-sourcing/v5/using-projectors/creating-and-configuring-projectors/) with this artisan command:
+ Events can be replayed to [all projectors that were added to the projectionist](/laravel-event-sourcing/v7/using-projectors/creating-and-configuring-projectors/) with this artisan command:
 
  ```bash
  php artisan event-sourcing:replay
@@ -29,7 +29,7 @@ If your projector has a `resetState` method it will get called before replaying 
 
 If you want to replay events starting from a certain event you can use the `--from` option when executing `event-sourcing:replay`. If you use this option the `resetState` on projectors will not get called. This package does not track which events have already been processed by which projectors. Be sure not to replay events to projectors that already have handled them.
 
-If you are [using your own event storage model](/laravel-event-sourcing/v4/advanced-usage/using-your-own-event-storage-model/) then you will need to use the `--stored-event-model` option when executing `event-sourcing:replay` to specify the model storing the events you want to replay.
+If you are [using your own event storage model](/laravel-event-sourcing/v7/advanced-usage/using-your-own-event-storage-model/) then you will need to use the `--stored-event-model` option when executing `event-sourcing:replay` to specify the model storing the events you want to replay.
 
 ```bash
 php artisan event-sourcing:replay --stored-event-model=App\\Models\\AccountStoredEvent

--- a/docs/advanced-usage/storing-metadata.md
+++ b/docs/advanced-usage/storing-metadata.md
@@ -9,7 +9,7 @@ You can add metadata, such as the `id` of the logged in user, to a stored event.
 
 If you need to store metadata on all events you can leverage Laravel's native models events when using the `EloquentStoredEventRepository`.
 
-You must configure the package to [use your own eloquent event storage model](/laravel-event-sourcing/v5/advanced-usage/using-your-own-event-storage-model) that extends the `EloquentStoredEvent` model. On that model you can hook into the model lifecycle hooks.
+You must configure the package to [use your own eloquent event storage model](/laravel-event-sourcing/v7/advanced-usage/using-your-own-event-storage-model) that extends the `EloquentStoredEvent` model. On that model you can hook into the model lifecycle hooks.
 
 ```php
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;

--- a/docs/getting-familiar-with-event-sourcing/introduction.md
+++ b/docs/getting-familiar-with-event-sourcing/introduction.md
@@ -9,7 +9,7 @@ Event sourcing tries to solve this problem by storing all events that happen in 
 
 Here's a concrete example to make it more clear. Imagine you're a bank. Your clients have accounts. Storing the balance of the accounts wouldn't be enough; all the transactions should be remembered too. With event sourcing, the balance isn't a standalone database field, but a value calculated from the stored transactions.
 
-After taking a look at [an example of traditional application](/laravel-event-sourcing/v5/getting-familiar-with-event-sourcing/the-traditional-application), we're going to discuss the two concepts that make up this package: [projectors](/laravel-event-sourcing/v5/getting-familiar-with-event-sourcing/using-projectors-to-transform-events) and [aggregates](/laravel-event-sourcing/v5/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
+After taking a look at [an example of traditional application](/laravel-event-sourcing/v7/getting-familiar-with-event-sourcing/the-traditional-application), we're going to discuss the two concepts that make up this package: [projectors](/laravel-event-sourcing/v7/getting-familiar-with-event-sourcing/using-projectors-to-transform-events) and [aggregates](/laravel-event-sourcing/v7/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
 
 If you want to skip to reading code immediately, here are the Larabank example apps used in this section. In all of them, you can create accounts and deposit or withdraw money.
 

--- a/docs/getting-familiar-with-event-sourcing/the-traditional-application.md
+++ b/docs/getting-familiar-with-event-sourcing/the-traditional-application.md
@@ -11,14 +11,14 @@ You might think that you still have the old state inside your backups. But they 
     <figcaption class="scheme_caption">
         First, we write value X
     </figcaption>
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/db-01.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/db-01.svg">
 </figure>
 
 <figure class="scheme">
     <figcaption class="scheme_caption">
         Next, we overwrite X by Y. X cannot be accessed anymore.
     </figcaption>
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/db-02.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/db-02.svg">
 </figure>
 
 Here's a demo application that uses a traditional architecture. Inside the [`AccountsController`](https://github.com/spatie/larabank-traditional/blob/9cc38858c50a4f2ac5a36e64719c891fac85bd3f/app/Http/Controllers/AccountsController.php) we are just going to [create new accounts](https://github.com/spatie/larabank-traditional/blob/9cc38858c50a4f2ac5a36e64719c891fac85bd3f/app/Http/Controllers/AccountsController.php#L19-L27) and [update the balance](https://github.com/spatie/larabank-traditional/blob/9cc38858c50a4f2ac5a36e64719c891fac85bd3f/app/Http/Controllers/AccountsController.php#L29-L36). We're using an eloquent model to update the database. Whenever we change the balance of the account, the old value is lost.

--- a/docs/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past.md
+++ b/docs/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past.md
@@ -12,25 +12,25 @@ Let's go through this step by step.
 Step 1: our app wants to subtract $1000. We create a new aggregate root instance and will feed it all events. There are no events yet to retrieve in this pass. The aggregate will conclude that it's allowed to subtract $1000 and will record that `Subtract` event. This recording is just in memory, and nothing will be written to the DB yet.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-01.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/aggregate-01.svg">
 </figure>
 
 Step 2: We are going to persist the aggregate. When persisting an aggregate, all of the newly recorded events that aggregate will be written in the database. Also, if you have projectors set up, they will receive the newly persisted events as well.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-02.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/aggregate-02.svg">
 </figure>
 
 Step 3: Let's hit that account limit and try to subtract $4800 now. First, the aggregate will be reconstituted from all previous events. Because it gets the earlier events it can calculate the current balance in memory (which is of course -$1000). The aggregate root can conclude that if we were to subtract $4800 we would cross our limit of -$5000. So it is not going to record that event. Instead, we could record that fact the account limit was hit.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-03.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/aggregate-03.svg">
 </figure>
 
 Step 4: The aggregate gets persisted, and the account limit hit event gets written into the database.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-04.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/aggregate-04.svg">
 </figure>
 
 So now we've protected our account from going below -\$5000. Let's take it one step further and send our customer a loan proposal mail when he or she hits the account limit three times in a row. Using an aggregate this is easy!
@@ -38,13 +38,13 @@ So now we've protected our account from going below -\$5000. Let's take it one s
 Step 5: Let's again try to subtract a lot of money to hit that account limit of \$5000. We hit our account limit the second time.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-05.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/aggregate-05.svg">
 </figure>
 
 Step 6: This time it gets interesting. We are going to try to subtract money and will hit our limit for the third time. Our aggregate gets reconstituted from all events. Those events get fed to the aggregate one by one. The aggregate in memory holds a counter of how many limit hit events it receives. That counter is now on 2. Because the amount we subtract will take us over the account limit, the aggregate will not record a subtract event, but a new limit hit event. It will update the limit hit counter from 2 to 3. Because the counter is now at 3. It can also record a new event called loan proposed. When storing the aggregate, the new events will get persisted in the database. All projectors and reactor will get called with these events. The `LoanProposalReactor` hears that `LoanProposed` event and send the mail.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/aggregate-06.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/aggregate-06.svg">
 </figure>
 
 All of the above is a lot to wrap your mind around. To help you understand this better, here's our Larabank app again, but this time built [using aggregates](https://github.com/spatie/larabank-aggregates). In the controller, you see that we don't fire events, but we are [using an aggregate](https://github.com/spatie/larabank-aggregates/blob/cc9c85fb6569aa9259fe7f9bdd5ee23ec92b0c66/app/Http/Controllers/AccountsController.php#L21-L52). Inside the aggregate we are going to [record events](https://github.com/spatie/larabank-aggregates/blob/cc9c85fb6569aa9259fe7f9bdd5ee23ec92b0c66/app/Domain/Account/AccountAggregateRoot.php#L34) that will get written to the database as soon as we [persist](https://github.com/spatie/larabank-aggregates/blob/cc9c85fb6569aa9259fe7f9bdd5ee23ec92b0c66/app/Http/Controllers/AccountsController.php#L40) the aggregate.
@@ -53,4 +53,4 @@ Whenever we retrieve an aggregate, all of the previously stored events will be f
 
 In summary, aggregates are used to make decisions based on past events.
 
-If you want to know how to create and use aggregates, head over to [the `using-aggregates` section](/laravel-event-sourcing/v5/using-aggregates/writing-your-first-aggregate).
+If you want to know how to create and use aggregates, head over to [the `using-aggregates` section](/laravel-event-sourcing/v7/using-aggregates/writing-your-first-aggregate).

--- a/docs/getting-familiar-with-event-sourcing/using-projectors-to-transform-events.md
+++ b/docs/getting-familiar-with-event-sourcing/using-projectors-to-transform-events.md
@@ -3,7 +3,7 @@ title: Using projectors to transform events
 weight: 3
 ---
 
-Let's build a bit further on the [Larabank example](https://github.com/spatie/larabank-traditional) mentioned in [the previous section](/laravel-event-sourcing/v5/getting-familiar-with-event-sourcing/the-traditional-application). The main drawback highlighted that example is the fact that when updating a value, we lose the old value. Let's solve that problem.
+Let's build a bit further on the [Larabank example](https://github.com/spatie/larabank-traditional) mentioned in [the previous section](/laravel-event-sourcing/v7/getting-familiar-with-event-sourcing/the-traditional-application). The main drawback highlighted that example is the fact that when updating a value, we lose the old value. Let's solve that problem.
 
 Instead of directly updating the value in the database, we could write every change we want to make as an event in our database.
 
@@ -11,30 +11,30 @@ Instead of directly updating the value in the database, we could write every cha
     <figcaption class="scheme_caption">
         Here we write our first event in the database
     </figcaption>
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/transform-01.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/transform-01.svg">
 </figure>
 
 <figure class="scheme">
     <figcaption class="scheme_caption">
         When new events come in, we'll write them to the events table as well
     </figcaption>
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/transform-02.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/transform-02.svg">
 </figure>
 
 All events get passed to a class we call a projector. The projector transforms the events to a format that is handy to use in our app. In our Larabank example, the events table hold the info of the individual transactions like `MoneyAdded` and `MoneySubtracted`. A projector could build an `Accounts` table based on those transactions.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/transform-03.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/transform-03.svg">
 </figure>
 
 Imagine that you've already stored some events, and your first projector is doing its job creating that `Accounts` table. The bank director now wants to know on which accounts the most transactions were performed. No problem, we could create another projector that reads all previous events and adds the `MoneyAdded` and `MoneySubtracted` events to make projections.
 
 <figure class="scheme">
-    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v5/images/transform-04.svg">
+    <img class="scheme_figure" src="/docs/laravel-event-sourcing/v7/images/transform-04.svg">
 </figure>
 
 This package can help you store native Laravel events in a `stored_events` table and create projectors that transform those events.
 
 Here's our example app [Larabank rebuild with projectors](https://github.com/spatie/larabank-projectors). In [the `AccountsController`](https://github.com/spatie/larabank-projectors/blob/677777c0cb7fd2584b54073ac82c91e25fd07d2b/app/Http/Controllers/AccountsController.php#L20-L36) we're not going to directly modify the database anymore. Instead, the controller will call methods which will in [their turn fire off events](https://github.com/spatie/larabank-projectors/blob/677777c0cb7fd2584b54073ac82c91e25fd07d2b/app/Account.php#L15-L41). Our package will listen for those events (which implement the empty `ShouldBeStored` interface) and store them in the `stored_events` table. Those events will also get passed to [all registered projectors](https://github.com/spatie/larabank-projectors/blob/677777c0cb7fd2584b54073ac82c91e25fd07d2b/config/event-sourcing.php#L18-L20). The [`AccountsProjector`](https://github.com/spatie/larabank-projectors/blob/677777c0cb7fd2584b54073ac82c91e25fd07d2b/app/Projectors/AccountsProjector.php) will build the `Accounts` table using [a couple of events it listens for](https://github.com/spatie/larabank-projectors/blob/677777c0cb7fd2584b54073ac82c91e25fd07d2b/app/Projectors/AccountsProjector.php#L17-L20).
 
-If you want to know more about projectors and how to use them, head over to [the `using-projectors` section](/laravel-event-sourcing/v5/using-projectors/writing-your-first-projector).
+If you want to know more about projectors and how to use them, head over to [the `using-projectors` section](/laravel-event-sourcing/v7/using-projectors/writing-your-first-projector).

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -97,7 +97,7 @@ use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSo
     /*
      * In production, you likely don't want the package to auto discover the event handlers
      * on every request. The package can cache all registered event handlers.
-     * More info: https://docs.spatie.be/laravel-event-sourcing/v4/advanced-usage/discovering-projectors-and-reactors
+     * More info: https://docs.spatie.be/laravel-event-sourcing/v7/advanced-usage/discovering-projectors-and-reactors
      *
      * Here you can specify where the cache should be stored.
      */
@@ -105,7 +105,7 @@ use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSo
 ];
 ```
 
-The package will scan all classes of your project to [automatically discover projectors and reactors](/laravel-event-sourcing/v5/advanced-usage/discovering-projectors-and-reactors#discovering-projectors-and-reactors). In a production environment you probably should [cache auto discovered projectors and reactors](/laravel-event-sourcing/v5/advanced-usage/discovering-projectors-and-reactors#caching-discovered-projectors-and-reactors).
+The package will scan all classes of your project to [automatically discover projectors and reactors](/laravel-event-sourcing/v7/advanced-usage/discovering-projectors-and-reactors#discovering-projectors-and-reactors). In a production environment you probably should [cache auto discovered projectors and reactors](/laravel-event-sourcing/v7/advanced-usage/discovering-projectors-and-reactors#caching-discovered-projectors-and-reactors).
 
 It's recommended that you set up a queue. Specify the connection name in the `queue` key of the `event-sourcing` config file. This queue will be used to guarantee that the events will be processed by all projectors in the right order. You should make sure that the queue will process only one job at a time. In a local environment, where events have a very low chance of getting fired concurrently, it's probably ok to just use the `sync` driver.
 

--- a/docs/using-aggregates/writing-your-first-aggregate.md
+++ b/docs/using-aggregates/writing-your-first-aggregate.md
@@ -3,7 +3,7 @@ title: Writing your first aggregate
 weight: 1
 ---
 
-An aggregate is a class that decides to record events based on past events. To know more about their general purpose and the idea behind them, read this section on [using aggregates to make decisions-based-on-the-past](/laravel-event-sourcing/v5/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
+An aggregate is a class that decides to record events based on past events. To know more about their general purpose and the idea behind them, read this section on [using aggregates to make decisions-based-on-the-past](/laravel-event-sourcing/v7/getting-familiar-with-event-sourcing/using-aggregates-to-make-decisions-based-on-the-past).
 
 ## Creating an aggregate
 

--- a/docs/using-projectors/creating-and-configuring-projectors.md
+++ b/docs/using-projectors/creating-and-configuring-projectors.md
@@ -66,7 +66,7 @@ Just by adding a typehint of the event you want to handle makes our package call
 
 ## Getting the uuid of an event
 
-In most cases you want to have access to the event that was fired. When [using aggregates](/laravel-event-sourcing/v5/using-aggregates/writing-your-first-aggregate) your events probably won't contain the uuid associated with that event. To get to the uuid of an event simply call the `aggregateRootUuid()` method on the event object.
+In most cases you want to have access to the event that was fired. When [using aggregates](/laravel-event-sourcing/v7/using-aggregates/writing-your-first-aggregate) your events probably won't contain the uuid associated with that event. To get to the uuid of an event simply call the `aggregateRootUuid()` method on the event object.
 
 ```php
 // ...

--- a/docs/using-projectors/thinking-in-events.md
+++ b/docs/using-projectors/thinking-in-events.md
@@ -3,9 +3,9 @@ title: Thinking in events
 weight: 5
 ---
 
-In this example we're going to try to send a mail whenever an account is broke (balance below zero). You can do this with projectors and reactors alone, but aggregates might be a better fit for this. Aggregates make it easy to make decisions based on past events. Check out the section on [how to use aggregates](/laravel-event-sourcing/v5/using-aggregates/writing-your-first-aggregate) to learn more about them, or keep reading on this page if you don't want to use aggregates.
+In this example we're going to try to send a mail whenever an account is broke (balance below zero). You can do this with projectors and reactors alone, but aggregates might be a better fit for this. Aggregates make it easy to make decisions based on past events. Check out the section on [how to use aggregates](/laravel-event-sourcing/v7/using-aggregates/writing-your-first-aggregate) to learn more about them, or keep reading on this page if you don't want to use aggregates.
 
-Let's build upon the examples shown in the [writing your first projector](/laravel-event-sourcing/v5/using-projectors/writing-your-first-projector) and [handling side effects with reactors](/laravel-event-sourcing/v5/using-reactors/writing-your-first-reactor)' sections.
+Let's build upon the examples shown in the [writing your first projector](/laravel-event-sourcing/v7/using-projectors/writing-your-first-projector) and [handling side effects with reactors](/laravel-event-sourcing/v7/using-reactors/writing-your-first-reactor)' sections.
 
 Imagine you are tasked with sending a mail to an account holder whenever he or she is broke. You might think, that's easy, let's just check in a new reactor if the account balance is less than zero.
 

--- a/docs/using-reactors/writing-your-first-reactor.md
+++ b/docs/using-reactors/writing-your-first-reactor.md
@@ -5,7 +5,7 @@ weight: 1
 
 ## What is a reactor
 
-Now that you've [written your first projector](/laravel-event-sourcing/v5/using-projectors/writing-your-first-projector), let's learn how to handle side effects. With side effects we mean things like sending a mail, sending a notification, ... You only want to perform these actions when the original event happens. You don't want to do this work when replaying events.
+Now that you've [written your first projector](/laravel-event-sourcing/v7/using-projectors/writing-your-first-projector), let's learn how to handle side effects. With side effects we mean things like sending a mail, sending a notification, ... You only want to perform these actions when the original event happens. You don't want to do this work when replaying events.
 
 A reactor is a class, that much like a projector, listens for incoming events. Unlike projectors however, reactors will not get called when events are replayed. Reactors only will get called when the original event fires.
 


### PR DESCRIPTION
Fix documentation version cross-linking to other versions for v7. #396

All of the updated links/files seem to exist in the current branch too so no edits needed.

If we're happy with this one, I can pick up tidying up the older version branches too. 