### PR TITLE
Fix preserving event order when dispatched from aggregate root via event handler

### DIFF
--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -64,14 +64,12 @@ class StoredEvent implements Arrayable
 
     public function handleForAggregateRoot(): void
     {
-        $this->handle();
-
-        if (! config('event-sourcing.dispatch_events_from_aggregate_roots', false)) {
-            return;
+        if (config('event-sourcing.dispatch_events_from_aggregate_roots', false)) {
+            $this->event->firedFromAggregateRoot = true;
+            event($this->event);
         }
 
-        $this->event->firedFromAggregateRoot = true;
-        event($this->event);
+        $this->handle();
     }
 
     public function handle()

--- a/tests/TestClasses/AggregateRoots/Reactors/DoubleBalanceReactor.php
+++ b/tests/TestClasses/AggregateRoots/Reactors/DoubleBalanceReactor.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Reactors;
+
+use Spatie\EventSourcing\EventHandlers\Reactors\Reactor;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+
+class DoubleBalanceReactor extends Reactor
+{
+    public function onMoneyAdded(MoneyAdded $event)
+    {
+        /** @var \Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot $aggregateRoot */
+        $aggregateRoot = AccountAggregateRoot::retrieve($event->aggregateRootUuid());
+
+        $aggregateRoot->multiplyMoney(2)->persist();
+    }
+}


### PR DESCRIPTION
When firing event from reactor, dispatched event should go after event that triggered the reactor. Example:
`MoneyAdded -> DoubleBalanceReactor -> MoneyMultiplied`
currently dispatches events to the bus `MoneyMultiplied` first. This PR fixes that behaviour.