### PR TITLE
Fix snapshots in aggregate partials

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -75,6 +75,13 @@ return [
      */
     'snapshot_model' => Spatie\EventSourcing\Snapshots\EloquentSnapshot::class,
 
+    /**
+     * The key within an AggregateRoot under which snapshots of partials are stored.
+     * This is stored within the Aggregate state when snapshotted, and restored when
+     * a snapshot is retrieved.
+     */
+    'snapshot_partials_key' => '__esPartials',
+
     /*
      * This class is responsible for handling stored events. To add extra behaviour you
      * can change this to a class of your own. The only restriction is that

--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -75,13 +75,6 @@ return [
      */
     'snapshot_model' => Spatie\EventSourcing\Snapshots\EloquentSnapshot::class,
 
-    /**
-     * The key within an AggregateRoot under which snapshots of partials are stored.
-     * This is stored within the Aggregate state when snapshotted, and restored when
-     * a snapshot is retrieved.
-     */
-    'snapshot_partials_key' => '__esPartials',
-
     /*
      * This class is responsible for handling stored events. To add extra behaviour you
      * can change this to a class of your own. The only restriction is that

--- a/src/AggregateRoots/AggregatePartial.php
+++ b/src/AggregateRoots/AggregatePartial.php
@@ -3,6 +3,8 @@
 namespace Spatie\EventSourcing\AggregateRoots;
 
 use Ramsey\Uuid\Uuid;
+use ReflectionClass;
+use ReflectionProperty;
 use Spatie\EventSourcing\EventHandlers\AppliesEvents;
 use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 use Spatie\EventSourcing\StoredEvents\StoredEvent;
@@ -31,6 +33,17 @@ abstract class AggregatePartial
         foreach ($storedEvents as $storedEvent) {
             $this->applyStoredEvent($storedEvent);
         }
+    }
+
+    public function getState(): array
+    {
+        $class = new ReflectionClass($this);
+
+        return collect($class->getProperties(ReflectionProperty::IS_PUBLIC))
+            ->reject(fn (ReflectionProperty $reflectionProperty) => $reflectionProperty->isStatic())
+            ->mapWithKeys(function (ReflectionProperty $property) {
+                return [$property->getName() => $this->{$property->getName()}];
+            })->toArray();
     }
 
     public static function fake(): static

--- a/src/AggregateRoots/AggregatePartial.php
+++ b/src/AggregateRoots/AggregatePartial.php
@@ -46,6 +46,13 @@ abstract class AggregatePartial
             })->toArray();
     }
 
+    public function useState(array $state): void
+    {
+        foreach ($state as $key => $value) {
+            $this->$key = $value;
+        }
+    }
+
     public static function fake(): static
     {
         $aggregateRoot = FakeAggregateRootForPartial::retrieve(Uuid::uuid4()->toString());

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -210,7 +210,17 @@ abstract class AggregateRoot
     protected function useState(array $state): void
     {
         foreach ($state as $key => $value) {
-            $this->$key = $value;
+            if ($key === self::$partialsKey) {
+                foreach ($value as $partialKey => $partialState) {
+                    foreach ($this->resolvePartials() as $partial) {
+                        if ($partial::class === $partialKey) {
+                            $partial->useState($partialState);
+                        }
+                    }
+                }    
+            } else {
+                $this->$key = $value;
+            }
         }
     }
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -34,8 +34,6 @@ abstract class AggregateRoot
 
     protected int $aggregateVersionAfterReconstitution = 0;
 
-    protected static string $partialsKey = '__esPartials';
-
     /** @var \Illuminate\Support\Collection|\Spatie\EventSourcing\AggregateRoots\AggregatePartial[] */
     protected Collection $entities;
 
@@ -194,7 +192,7 @@ abstract class AggregateRoot
             ->mapWithKeys(function (ReflectionProperty $property) {
                 return [$property->getName() => $this->{$property->getName()}];
             })
-            ->put(self::$partialsKey, $this->getPartialsState())
+            ->put(config('event-sourcing.snapshot_partials_key'), $this->getPartialsState())
             ->toArray();
     }
 
@@ -210,7 +208,7 @@ abstract class AggregateRoot
     protected function useState(array $state): void
     {
         foreach ($state as $key => $value) {
-            if ($key === self::$partialsKey) {
+            if ($key === config('event-sourcing.snapshot_partials_key')) {
                 foreach ($value as $partialKey => $partialState) {
                     foreach ($this->resolvePartials() as $partial) {
                         if ($partial::class === $partialKey) {

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -182,8 +182,7 @@ it('should store partial states when snapshotting', function () {
     $aggregateRoot->snapshot();
 
     tap(EloquentSnapshot::first(), function (EloquentSnapshot $snapshot) {
-        assertCount(1, $snapshot->state['__esPartials']);
-        assertEquals(300, $snapshot->state['__esPartials'][MoneyPartial::class]['balance']);
+        assertEquals(300, $snapshot->state[MoneyPartial::class]['balance']);
     });
 });
 

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -223,6 +223,25 @@ it('should save events after the snapshot are reconstituted', function () {
     assertEquals(400, $aggregateRootRetrieved->balance);
 });
 
+it('should have partials reconstituted if present', function () {
+    /** @var \Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithPartial $aggregateRoot */
+    $aggregateRoot = AccountAggregateRootWithPartial::retrieve($this->aggregateUuid);
+
+    $aggregateRoot
+        ->addMoney(100)
+        ->addMoney(100)
+        ->addMoney(100)
+        ->persist();
+
+    $aggregateRoot->snapshot();
+    $aggregateRoot->addMoney(100)->persist();
+
+    $aggregateRootRetrieved = AccountAggregateRootWithPartial::retrieve($this->aggregateUuid);
+
+    assertEquals(4, $aggregateRootRetrieved->aggregateVersion);
+    assertEquals(400, $aggregateRootRetrieved->getBalance());
+});
+
 it('should replay all events in the correct order when retrieving an aggregate root all', function () {
     /** @var \Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot $aggregateRoot */
     $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid);

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRootWithPartial.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRootWithPartial.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots;
+
+use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Partials\MoneyPartial;
+
+class AccountAggregateRootWithPartial extends AggregateRoot
+{
+    public int $aggregateVersion = 0;
+
+    public int $aggregateVersionAfterReconstitution = 0;
+
+    public $dependency;
+
+    protected Math $math;
+
+    protected MoneyPartial $moneyPartial;
+
+    public function __construct(Math $math, $dependency = null)
+    {
+        $this->dependency = $dependency;
+        $this->math = $math;
+
+        $this->moneyPartial = new MoneyPartial($this, $math);
+    }
+
+    public function addMoney(int $amount): self
+    {
+        $this->moneyPartial->addMoney($amount);
+
+        return $this;
+    }
+
+    public function multiplyMoney(int $amount): self
+    {
+        $this->moneyPartial->multiplyMoney($amount);
+
+        return $this;
+    }
+
+    public function getBalance()
+    {
+        return $this->moneyPartial->balance;
+    }
+}

--- a/tests/TestClasses/AggregateRoots/Partials/MoneyPartial.php
+++ b/tests/TestClasses/AggregateRoots/Partials/MoneyPartial.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Partials;
+
+use Spatie\EventSourcing\AggregateRoots\AggregatePartial;
+use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Math;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyMultiplied;
+
+class MoneyPartial extends AggregatePartial
+{
+    public int $balance = 0;
+
+    protected Math $math;
+
+    public function __construct(AggregateRoot $aggregateRoot, Math $math)
+    {
+        parent::__construct($aggregateRoot);
+        $this->math = $math;
+    }
+
+    public function addMoney(int $amount): self
+    {
+        $this->recordThat(new MoneyAdded($amount));
+
+        return $this;
+    }
+
+    public function multiplyMoney(int $amount): self
+    {
+        $this->recordThat(new MoneyMultiplied($amount));
+
+        return $this;
+    }
+
+    protected function applyMoneyAdded(MoneyAdded $event)
+    {
+        $this->balance += $event->amount;
+    }
+
+    public function applyMoneyMultiplied(MoneyMultiplied $event)
+    {
+        $this->balance = $this->math->multiply($this->balance, $event->amount);
+    }
+
+}


### PR DESCRIPTION
This pull request is an attempted, updated fix for issue #307 where the states of partials are not restored when a snapshot is retrieved.

This update works by defining a single key (default `__esPartials`) in the event sourcing config file that is used as a key in the state of a snapshot. Each partial is then reflected for public properties, and a key that is the classname of the partial is added to the `__esPartials` in the generated. The value of that key is the state of the partial.

This will generate a snapshot state of:
```php
$state = [
    'foo' => 'bar',
    '__esPartials' => [
        'App/Partials/FooPartial' => [
            'fooProperty1' => 1,
            'fooProperty2' => true
    ],
];
````

Reconstitution of the snapshot goes through each key of __esPartials and matches to a resolved Partial Class, and sets the state of that Partials.
