### PR TITLE
`ReplayCommand` `--stored-event-model` option is no longer implemented

### DIFF
--- a/docs/advanced-usage/replaying-events.md
+++ b/docs/advanced-usage/replaying-events.md
@@ -29,12 +29,6 @@ If your projector has a `resetState` method it will get called before replaying 
 
 If you want to replay events starting from a certain event you can use the `--from` option when executing `event-sourcing:replay`. If you use this option the `resetState` on projectors will not get called. This package does not track which events have already been processed by which projectors. Be sure not to replay events to projectors that already have handled them.
 
-If you are [using your own event storage model](/laravel-event-sourcing/v7/advanced-usage/using-your-own-event-storage-model/) then you will need to use the `--stored-event-model` option when executing `event-sourcing:replay` to specify the model storing the events you want to replay.
-
-```bash
-php artisan event-sourcing:replay --stored-event-model=App\\Models\\AccountStoredEvent
- ```
-
 If you only want to reply events for a specific aggregate only, you can use the `--aggregate-uuid` option.
 
 ```bash

--- a/src/Commands/RunCommandJob.php
+++ b/src/Commands/RunCommandJob.php
@@ -29,18 +29,18 @@ class RunCommandJob implements ShouldQueue
          * For now, this functionality is disabled because we don't have a good way of handling it yet
          * https://github.com/spatie/laravel-event-sourcing/discussions/214
          */
-//        if (! $handler->forAggregateRoot()) {
-//            $handler->handle();
-//
-//            return;
-//        }
-//
-//        $lock = Cache::lock($handler->lockId());
-//
-//        if ($lock->get()) {
-//            $handler->handle();
-//
-//            $lock->release();
-//        }
+        //        if (! $handler->forAggregateRoot()) {
+        //            $handler->handle();
+        //
+        //            return;
+        //        }
+        //
+        //        $lock = Cache::lock($handler->lockId());
+        //
+        //        if ($lock->get()) {
+        //            $handler->handle();
+        //
+        //            $lock->release();
+        //        }
     }
 }

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -12,7 +12,6 @@ class ReplayCommand extends Command
 {
     protected $signature = 'event-sourcing:replay {projector?*}
                             {--from=0 : Replay events starting from this event number}
-                            {--stored-event-model= : Replay events from this store}
                             {--aggregate-uuid= : Replay events for this aggregate only}';
 
     protected $description = 'Replay stored events';

--- a/tests/Console/ReplayCommandTest.php
+++ b/tests/Console/ReplayCommandTest.php
@@ -105,20 +105,6 @@ it('will call certain methods on the projector when replaying events', function 
     ], BalanceProjector::$log);
 });
 
-it('will replay events from a specific store', function () {
-    $account = AccountAggregateRootWithStoredEventRepositorySpecified::create();
-
-    foreach (range(1, 5) as $i) {
-        event(new MoneyAddedEvent($account, 2000));
-    }
-
-    OtherEloquentStoredEvent::truncate();
-
-    $this->artisan('event-sourcing:replay', ['--stored-event-model' => OtherEloquentStoredEvent::class])
-        ->expectsOutput('Replaying 5 events...')
-        ->assertExitCode(0);
-})->skip();
-
 it('will replay events for a specific aggregate root uuid', function () {
     EloquentStoredEvent::truncate();
 

--- a/tests/Console/ReplayCommandTest.php
+++ b/tests/Console/ReplayCommandTest.php
@@ -14,13 +14,11 @@ use Spatie\EventSourcing\Events\StartingEventReplay;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
-use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRootWithStoredEventRepositorySpecified;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Projectors\AccountProjector;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneySubtractedEvent;
 use Spatie\EventSourcing\Tests\TestClasses\Mailables\AccountBroke;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
-use Spatie\EventSourcing\Tests\TestClasses\Models\OtherEloquentStoredEvent;
 use Spatie\EventSourcing\Tests\TestClasses\Projectors\BalanceProjector;
 use Spatie\EventSourcing\Tests\TestClasses\Reactors\BrokeReactor;
 


### PR DESCRIPTION
ReplayCommand `--stored-event-model` option is no longer implemented and the value isn't accessed in the command. As far as I can tell this is no longer needed as the custom model can be specified in config and the Eloquent repo respects that config value.

The test covering it is already skipped, so I assume this was just missed cleanup.

This PR, removes the option from the command, the reference in the docs and the skipped test.