### PR TITLE
Replay events with custom stored event model

### DIFF
--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -31,9 +31,7 @@ class ReplayCommand extends Command
             return;
         }
 
-        if ($this->hasOption('stored-event-model')) {
-            $model = $this->option('stored-event-model');
-
+        if ($model = $this->option('stored-event-model')) {
             if (! class_exists($model)) {
                 throw new Exception("Model {$model} not found. Make sure the model namespace is correct.");
             }

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -31,6 +31,16 @@ class ReplayCommand extends Command
             return;
         }
 
+        if ($this->hasArgument('stored-event-model')) {
+            $model = $this->argument('stored-event-model');
+
+            if (! class_exists($model)) {
+                throw new Exception("Model {$model} not found. Make sure the model namespace is correct.");
+            }
+
+            config(['event-sourcing.stored_event_model' => $model]);
+        }
+
         $this->replay($projectors, (int)$this->option('from'), $this->option('aggregate-uuid'));
     }
 

--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -31,8 +31,8 @@ class ReplayCommand extends Command
             return;
         }
 
-        if ($this->hasArgument('stored-event-model')) {
-            $model = $this->argument('stored-event-model');
+        if ($this->hasOption('stored-event-model')) {
+            $model = $this->option('stored-event-model');
 
             if (! class_exists($model)) {
                 throw new Exception("Model {$model} not found. Make sure the model namespace is correct.");

--- a/tests/Console/ReplayCommandTest.php
+++ b/tests/Console/ReplayCommandTest.php
@@ -110,13 +110,11 @@ it('will call certain methods on the projector when replaying events', function 
 it('will replay events from a specific store', function () {
     $uuid = FakeUuid::generate();
 
-    Collection::times(
-        5,
-        fn () =>
+    foreach (range(1, 5) as $i) {
         AccountAggregateRootWithStoredEventRepositorySpecified::retrieve($uuid)
             ->addMoney(2000)
-            ->persist()
-    );
+            ->persist();
+    };
 
     $projector = app(AccountProjector::class);
     Projectionist::addProjector($projector);

--- a/tests/Console/ReplayCommandTest.php
+++ b/tests/Console/ReplayCommandTest.php
@@ -108,8 +108,6 @@ it('will call certain methods on the projector when replaying events', function 
 });
 
 it('will replay events from a specific store', function () {
-    // OtherEloquentStoredEvent::truncate();
-
     $uuid = FakeUuid::generate();
 
     Collection::times(5, fn () =>
@@ -118,7 +116,13 @@ it('will replay events from a specific store', function () {
             ->persist()
     );
 
-    $this->artisan('event-sourcing:replay', ['--stored-event-model' => OtherEloquentStoredEvent::class])
+    $projector = app(AccountProjector::class);
+    Projectionist::addProjector($projector);
+
+    $this->artisan('event-sourcing:replay', [
+        'projector' => [AccountProjector::class],
+        '--stored-event-model' => OtherEloquentStoredEvent::class
+    ])
         ->expectsOutput('Replaying 5 events...')
         ->assertExitCode(0);
 });

--- a/tests/Console/ReplayCommandTest.php
+++ b/tests/Console/ReplayCommandTest.php
@@ -123,7 +123,7 @@ it('will replay events from a specific store', function () {
 
     $this->artisan('event-sourcing:replay', [
         'projector' => [AccountProjector::class],
-        '--stored-event-model' => OtherEloquentStoredEvent::class
+        '--stored-event-model' => OtherEloquentStoredEvent::class,
     ])
         ->expectsOutput('Replaying 5 events...')
         ->assertExitCode(0);


### PR DESCRIPTION
ReplayCommand `--stored-event-model` option is not implemented even though it's [documented](https://spatie.be/docs/laravel-event-sourcing/v7/advanced-usage/replaying-events).

> If you are [using your own event storage model](https://spatie.be/docs/laravel-event-sourcing/v7/advanced-usage/using-your-own-event-storage-model/) then you will need to use the --stored-event-model option when executing event-sourcing:replay to specify the model storing the events you want to replay.

This option would be especially useful when the application stores events in different tables depending on the domain. In this scenario, specifying the custom model in the config doesn't work since the custom model will be dynamically determined based on the domain.
Related discussion: https://github.com/spatie/laravel-event-sourcing/discussions/347