### PR TITLE
dont overwrite created_at if already set

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -105,7 +105,7 @@ abstract class AggregateRoot
     {
         $domainEvent
             ->setAggregateRootUuid($this->uuid)
-            ->setCreatedAt(CarbonImmutable::now());
+            ->setCreatedAt($domainEvent->createdAt() ?? CarbonImmutable::now());
 
         $this->recordedEvents[] = $domainEvent;
 

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -402,6 +402,23 @@ it('should set created at from within the aggregate root', function () {
     assertTrue($now->eq($event->createdAt()));
 });
 
+it('should not overwrite created at, from within the aggregate root, if already defined', function () {
+    app(AccountAggregateRoot::class)
+        ->loadUuid($this->aggregateUuid)
+        ->recordThat(
+            (new MoneyAdded(100))
+                ->setCreatedAt($when = CarbonImmutable::make('2021-01-01 01:02:03'))
+        )
+        ->persist();
+
+    /** @var \Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent $eloquentEvent */
+    $eloquentEvent = EloquentStoredEvent::first();
+
+    $event = $eloquentEvent->toStoredEvent()->event;
+
+    assertTrue($when->eq($event->createdAt()));
+});
+
 it('should always retrieve the last snapshot', function () {
     Carbon::setTestNow();
 


### PR DESCRIPTION
This introduces the ability to manually set the "created_at" for events when dispatching them through aggregates.

This is useful, especially during the migration of an existing application to event sourcing, where it is necessary to preserve the "created at" metadata.

I encountered this need myself while writing a console command that resembles the code snippet below, and realised that the `recordThat()` method would overwrite the "created at" value I had specified.

```PHP
SomeModel::cursor()->each(function(SomeModel $original) {
    $event = new SomethingHappened();
    $event->setCreatedAt($original->created_at->toImmutable());

    SomeAggregate::retrieve(...)
                 ->recordThat($event)
                 ->persist();
});
```