### PR TITLE
Fix Symfony Serializer Deprecation Warnings

### DIFF
--- a/src/Support/CarbonNormalizer.php
+++ b/src/Support/CarbonNormalizer.php
@@ -45,4 +45,9 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     {
         return is_a($type, CarbonInterface::class, true);
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [CarbonInterface::class => false];
+    }
 }

--- a/src/Support/ModelIdentifierNormalizer.php
+++ b/src/Support/ModelIdentifierNormalizer.php
@@ -68,4 +68,9 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
         return is_a($class, QueueableEntity::class, true)
             || is_a($class, QueueableCollection::class, true);
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return [QueueableEntity::class => false, QueueableCollection::class => false];
+    }
 }

--- a/src/Support/ObjectNormalizer.php
+++ b/src/Support/ObjectNormalizer.php
@@ -24,4 +24,9 @@ class ObjectNormalizer extends SymfonyObjectNormalizer
             $defaultContext
         );
     }
+
+    public function getSupportedTypes(?string $format): array
+    {
+        return ['object' => false];
+    }
 }


### PR DESCRIPTION
Symfony serializer 6.3 triggers a deprecation error when a normalizer does not define a `getSupportedTypes` method or when a call is made to `hasCacheableSupportsMethod` on a Symfony provided normalizer.

https://github.com/symfony/serializer/compare/6.2...v6.3.0#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR13

https://github.com/symfony/serializer/compare/6.2...v6.3.0#diff-51c0e7020499be2a667ccb570a642fca293da2451cca31cec2ecc467ecf58b51R37

https://github.com/symfony/serializer/compare/6.2...v6.3.0#diff-05d8706b90462cdef57865a942e5a6a6bbb87924ee9830fb94555a6022607d73R63

Examples:

```
ErrorException: Since symfony/serializer 6.3: "Spatie\EventSourcing\Support\CarbonNormalizer" should implement "NormalizerInterface::getSupportedTypes(?string $format): array". in /var/task/vendor/symfony/deprecation-contracts/function.php:25 Stack trace: #0
```

```
ErrorException: Since symfony/serializer 6.3: "Spatie\EventSourcing\Support\ModelIdentifierNormalizer" should implement "DenormalizerInterface::getSupportedTypes(?string $format): array". in /var/task/vendor/symfony/deprecation-contracts/function.php:25 Stack trace: #0
```

```
ErrorException: Since symfony/serializer 6.3: The "Symfony\Component\Serializer\Normalizer\ObjectNormalizer::hasCacheableSupportsMethod()" method is deprecated, use "getSupportedTypes()" instead. in /var/task/vendor/symfony/deprecation-contracts/function.php:25 Stack trace: #0
```

This PR prevents these deprecation warnings. 