### PR TITLE
Correcting Commands Documentation

### DIFF
--- a/docs/advanced-usage/commands.md
+++ b/docs/advanced-usage/commands.md
@@ -12,10 +12,9 @@ namespace Spatie\Shop\Cart\Commands;
 
 use Spatie\Shop\Support\EventSourcing\Attributes\AggregateUuid;
 use Spatie\Shop\Support\EventSourcing\Attributes\HandledBy;
-use Spatie\Shop\Support\EventSourcing\Commands\Command;
 
 #[HandledBy(CartAggregateRoot::class)]
-class AddCartItem implements Command
+class AddCartItem
 {
     public function __construct(
         #[AggregateUuid] public string $cartUuid,


### PR DESCRIPTION
Updated to show that commands not longer implement `Spatie\Shop\Support\EventSourcing\Commands\Command` interface