### PR TITLE
Support recording events concurrently

### DIFF
--- a/src/AggregateRoots/AggregatePartial.php
+++ b/src/AggregateRoots/AggregatePartial.php
@@ -28,6 +28,13 @@ abstract class AggregatePartial
         return $this;
     }
 
+    protected function recordConcurrently(ShouldBeStored $domainEvent, ?callable $allowConcurrent = null): static
+    {
+        $this->aggregateRoot->recordConcurrently($domainEvent, $allowConcurrent);
+
+        return $this;
+    }
+
     public function apply(StoredEvent | ShouldBeStored ...$storedEvents): void
     {
         foreach ($storedEvents as $storedEvent) {

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -138,6 +138,16 @@ abstract class AggregateRoot
 
     public function persist(): static
     {
+        foreach ($this->recordedEvents as $i => $recordedEvent) {
+            $concurrencyCheck = $this->concurrencyChecks[$i];
+
+            if (is_null($concurrencyCheck)) {
+                continue;
+            }
+
+            $concurrencyCheck($this);
+        }
+
         $storedEvents = $this->persistWithoutApplyingToEventHandlers();
 
         if ($this->handleEvents) {

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -158,6 +158,9 @@ abstract class AggregateRoot
                 throw $exception;
             }
 
+            // @todo Instead of creating a new instance, this should reset the aggregate root state back to it's
+            //       initial state after __construct, then re-retrieve events from the database and apply them
+            //       on the resetted aggregate root.
             $newInstance = static::retrieve($this->uuid());
             $newInstance->concurrentTries = $this->concurrentTries + 1;
 
@@ -173,6 +176,7 @@ abstract class AggregateRoot
                 $newInstance->recordConcurrently($recordedEvent, $concurrencyCheck);
             }
 
+            // @todo Don't return a new instance but the same one, see above todo
             return $newInstance->persist();
         }
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -153,12 +153,13 @@ abstract class AggregateRoot
         try {
             $storedEvents = $this->persistWithoutApplyingToEventHandlers();
         } catch (CouldNotPersistAggregate $exception) {
-            $newInstance = static::retrieve($this->uuid());
-            $newInstance->concurrentTries = $this->concurrentTries + 1;
-
-            if ($newInstance->maximumTries !== -1 && $newInstance->concurrentTries > $newInstance->maximumTries) {
+            // @todo Add tests for maximum tries
+            if ($this->maximumTries !== -1 && $this->concurrentTries >= $this->maximumTries) {
                 throw $exception;
             }
+
+            $newInstance = static::retrieve($this->uuid());
+            $newInstance->concurrentTries = $this->concurrentTries + 1;
 
             foreach ($recordedEvents as $i => $recordedEvent) {
                 $concurrencyCheck = $concurrencyChecks[$i];

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -125,12 +125,8 @@ abstract class AggregateRoot
         return $this;
     }
 
-    public function recordConcurrently(ShouldBeStored $domainEvent, bool|callable $allowConcurrent = true): static
+    public function recordConcurrently(ShouldBeStored $domainEvent, ?callable $allowConcurrent = null): static
     {
-        if (! $allowConcurrent) {
-            return $this->recordThat($domainEvent);
-        }
-
         if (is_callable($allowConcurrent)) {
             $allowConcurrent($this);
         }
@@ -139,7 +135,7 @@ abstract class AggregateRoot
 
         $this->concurrencyChecks[count($this->concurrencyChecks) - 1] = is_callable($allowConcurrent)
             ? $allowConcurrent
-            : fn () => $allowConcurrent;
+            : fn () => true;
 
         return $this;
     }

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -43,7 +43,7 @@ abstract class AggregateRoot
 
     private int $maximumTries = -1;
 
-    /** @var callable[] $concurrencyChecks */
+    /** @var callable[] */
     private array $concurrencyChecks = [];
 
     /**

--- a/src/AggregateRoots/Exceptions/CouldNotPersistAggregate.php
+++ b/src/AggregateRoots/Exceptions/CouldNotPersistAggregate.php
@@ -4,6 +4,7 @@ namespace Spatie\EventSourcing\AggregateRoots\Exceptions;
 
 use Exception;
 use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 
 class CouldNotPersistAggregate extends Exception
 {
@@ -27,5 +28,17 @@ class CouldNotPersistAggregate extends Exception
         $uuid = $aggregateRoot->uuid();
 
         return new static("Could not persist aggregate {$aggregateRootClass} (uuid: {$uuid}) because it seems to be changed by another process after it was retrieved in the current process. Current in-memory version is {$currentVersion}");
+    }
+
+    public static function concurrencyCheckFailed(
+        AggregateRoot $aggregateRoot,
+        ShouldBeStored $shouldBeStored,
+    ): self {
+        $aggregateRootClass = class_basename($aggregateRoot);
+        $eventClass = class_basename($shouldBeStored);
+
+        $uuid = $aggregateRoot->uuid();
+
+        return new static("Could not persist aggregate {$aggregateRootClass} (uuid: {$uuid}) because a concurrency check failed on event {$eventClass}.");
     }
 }

--- a/src/AggregateRoots/Exceptions/CouldNotPersistAggregate.php
+++ b/src/AggregateRoots/Exceptions/CouldNotPersistAggregate.php
@@ -4,7 +4,6 @@ namespace Spatie\EventSourcing\AggregateRoots\Exceptions;
 
 use Exception;
 use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
-use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 
 class CouldNotPersistAggregate extends Exception
 {
@@ -28,17 +27,5 @@ class CouldNotPersistAggregate extends Exception
         $uuid = $aggregateRoot->uuid();
 
         return new static("Could not persist aggregate {$aggregateRootClass} (uuid: {$uuid}) because it seems to be changed by another process after it was retrieved in the current process. Current in-memory version is {$currentVersion}");
-    }
-
-    public static function concurrencyCheckFailed(
-        AggregateRoot $aggregateRoot,
-        ShouldBeStored $shouldBeStored,
-    ): self {
-        $aggregateRootClass = class_basename($aggregateRoot);
-        $eventClass = class_basename($shouldBeStored);
-
-        $uuid = $aggregateRoot->uuid();
-
-        return new static("Could not persist aggregate {$aggregateRootClass} (uuid: {$uuid}) because a concurrency check failed on event {$eventClass}.");
     }
 }

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -338,6 +338,17 @@ it('respects tries with concurrently', function () {
     $aggregateRoot->persistConcurrently(1);
 })->throws(CouldNotPersistAggregate::class);
 
+it('respects allowConcurrent false in recordConcurrently', function () {
+    $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
+    $aggregateRoot->addMoneyNonConcurrent(100);
+
+    $aggregateRootInAnotherRequest = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
+    $aggregateRootInAnotherRequest->addMoneyNonConcurrent(100);
+    $aggregateRootInAnotherRequest->persistConcurrently();
+
+    $aggregateRoot->persistConcurrently();
+})->throws(CouldNotPersistAggregate::class);
+
 it('allows concurrency with concurrently under specific conditions', function () {
     $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
     $aggregateRoot->addMoney(100);
@@ -371,13 +382,6 @@ it('does not allow concurrency when a non-concurrent event was also recorded', f
 it('also validates concurrency checks before persisting', function () {
     $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
     $aggregateRoot->removeMoney(100);
-    $aggregateRoot->persist();
-})->throws(Exception::class, 'Insufficient balance');
-
-it('also validates concurrency checks before persisting concurrently', function () {
-    $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
-    $aggregateRoot->removeMoney(100);
-    $aggregateRoot->persistConcurrently();
 })->throws(Exception::class, 'Insufficient balance');
 
 it('fires the triggered events on the event bus when configured', function () {

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -314,12 +314,11 @@ it('allows concurrency with concurrently', function () {
 
     $aggregateRootInAnotherRequest = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
     $aggregateRootInAnotherRequest->addMoney(100);
-    $aggregateRootInAnotherRequest->persist();
+    $aggregateRootInAnotherRequest->persistConcurrently();
 
-    // @todo Keep the same instance
-    $aggregateRoot = $aggregateRoot->persist();
+    $newAggregateRoot = $aggregateRoot->persistConcurrently();
 
-    expect($aggregateRoot->balance)->toBe(200);
+    expect($newAggregateRoot->balance)->toBe(200);
 
     // Not refreshed
     expect($aggregateRootInAnotherRequest->balance)->toBe(100);
@@ -337,13 +336,13 @@ it('allows concurrency with concurrently under specific conditions', function ()
     $aggregateRootInAnotherRequestC = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
 
     $aggregateRootInAnotherRequestA->addMoney(100);
-    $aggregateRootInAnotherRequestA->persist();
+    $aggregateRootInAnotherRequestA->persistConcurrently();
 
     $aggregateRootInAnotherRequestB->removeMoney(100);
-    $aggregateRootInAnotherRequestB->persist();
+    $aggregateRootInAnotherRequestB->persistConcurrently();
 
     $aggregateRootInAnotherRequestC->removeMoney(200);
-    $aggregateRootInAnotherRequestC->persist();
+    $aggregateRootInAnotherRequestC->persistConcurrently();
 })->throws(Exception::class, 'Insufficient balance');
 
 it('does not allow concurrency when a non-concurrent event was also recorded', function () {
@@ -355,13 +354,13 @@ it('does not allow concurrency when a non-concurrent event was also recorded', f
     $aggregateRootInAnotherRequest->addMoney(100);
     $aggregateRootInAnotherRequest->persist();
 
-    $aggregateRoot->persist();
+    $aggregateRoot->persistConcurrently();
 })->throws(CouldNotPersistAggregate::class);
 
 it('also validates concurrency checks before persisting', function () {
     $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
     $aggregateRoot->removeMoney(100);
-    $aggregateRoot->persist();
+    $aggregateRoot->persistConcurrently();
 })->throws(Exception::class, 'Insufficient balance');
 
 it('fires the triggered events on the event bus when configured', function () {

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -327,6 +327,17 @@ it('allows concurrency with concurrently', function () {
     expect($fresh->balance)->toBe(200);
 });
 
+it('respects tries with concurrently', function () {
+    $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
+    $aggregateRoot->addMoney(100);
+
+    $aggregateRootInAnotherRequest = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
+    $aggregateRootInAnotherRequest->addMoney(100);
+    $aggregateRootInAnotherRequest->persistConcurrently(1);
+
+    $aggregateRoot->persistConcurrently(1);
+})->throws(CouldNotPersistAggregate::class);
+
 it('allows concurrency with concurrently under specific conditions', function () {
     $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
     $aggregateRoot->addMoney(100);

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -371,6 +371,12 @@ it('does not allow concurrency when a non-concurrent event was also recorded', f
 it('also validates concurrency checks before persisting', function () {
     $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
     $aggregateRoot->removeMoney(100);
+    $aggregateRoot->persist();
+})->throws(Exception::class, 'Insufficient balance');
+
+it('also validates concurrency checks before persisting concurrently', function () {
+    $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
+    $aggregateRoot->removeMoney(100);
     $aggregateRoot->persistConcurrently();
 })->throws(Exception::class, 'Insufficient balance');
 

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -344,7 +344,7 @@ it('allows concurrency with concurrently under specific conditions', function ()
 
     $aggregateRootInAnotherRequestC->removeMoney(200);
     $aggregateRootInAnotherRequestC->persist();
-})->throws(CouldNotPersistAggregate::class);
+})->throws(Exception::class, 'Insufficient balance');
 
 it('does not allow concurrency when a non-concurrent event was also recorded', function () {
     $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
@@ -357,6 +357,12 @@ it('does not allow concurrency when a non-concurrent event was also recorded', f
 
     $aggregateRoot->persist();
 })->throws(CouldNotPersistAggregate::class);
+
+it('also validates concurrency checks before persisting', function () {
+    $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
+    $aggregateRoot->removeMoney(100);
+    $aggregateRoot->persist();
+})->throws(Exception::class, 'Insufficient balance');
 
 it('fires the triggered events on the event bus when configured', function () {
     config()->set('event-sourcing.dispatch_events_from_aggregate_roots', true);

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -338,17 +338,6 @@ it('respects tries with concurrently', function () {
     $aggregateRoot->persistConcurrently(1);
 })->throws(CouldNotPersistAggregate::class);
 
-it('respects allowConcurrent false in recordConcurrently', function () {
-    $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
-    $aggregateRoot->addMoneyNonConcurrent(100);
-
-    $aggregateRootInAnotherRequest = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
-    $aggregateRootInAnotherRequest->addMoneyNonConcurrent(100);
-    $aggregateRootInAnotherRequest->persistConcurrently();
-
-    $aggregateRoot->persistConcurrently();
-})->throws(CouldNotPersistAggregate::class);
-
 it('allows concurrency with concurrently under specific conditions', function () {
     $aggregateRoot = AccountAggregateRootWithConcurrency::retrieve($this->aggregateUuid);
     $aggregateRoot->addMoney(100);

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRootWithConcurrency.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRootWithConcurrency.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots;
+
+use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyMultiplied;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyRemoved;
+
+class AccountAggregateRootWithConcurrency extends AggregateRoot
+{
+    public int $balance = 0;
+
+    protected Math $math;
+
+    public function __construct(Math $math)
+    {
+        $this->math = $math;
+    }
+
+    public function addMoney(int $amount): self
+    {
+        $this->recordConcurrently(new MoneyAdded($amount));
+
+        return $this;
+    }
+
+    protected function applyMoneyAdded(MoneyAdded $event)
+    {
+        $this->balance += $event->amount;
+    }
+
+    public function removeMoney(int $amount): self
+    {
+        $this
+            ->recordConcurrently(
+                new MoneyRemoved($amount),
+                function (self $aggregateRootWithConcurrency) use ($amount) {
+                    return $aggregateRootWithConcurrency->balance > $amount;
+                },
+            );
+
+        return $this;
+    }
+
+    protected function applyMoneyRemoved(MoneyRemoved $event)
+    {
+        $this->balance -= $event->amount;
+    }
+
+    public function multiplyMoney(int $amount): self
+    {
+        $this->recordThat(new MoneyMultiplied($amount));
+
+        return $this;
+    }
+
+    public function applyMoneyMultiplied(MoneyMultiplied $event)
+    {
+        $this->balance = $this->math->multiply($this->balance, $event->amount);
+    }
+}

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRootWithConcurrency.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRootWithConcurrency.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots;
 
+use Exception;
 use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyMultiplied;
@@ -36,7 +37,9 @@ class AccountAggregateRootWithConcurrency extends AggregateRoot
             ->recordConcurrently(
                 new MoneyRemoved($amount),
                 function (self $aggregateRootWithConcurrency) use ($amount) {
-                    return $aggregateRootWithConcurrency->balance > $amount;
+                    if ($aggregateRootWithConcurrency->balance < $amount) {
+                        throw new Exception('Insufficient balance');
+                    }
                 },
             );
 

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRootWithConcurrency.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRootWithConcurrency.php
@@ -26,6 +26,13 @@ class AccountAggregateRootWithConcurrency extends AggregateRoot
         return $this;
     }
 
+    public function addMoneyNonConcurrent(int $amount): self
+    {
+        $this->recordConcurrently(new MoneyAdded($amount), false);
+
+        return $this;
+    }
+
     protected function applyMoneyAdded(MoneyAdded $event)
     {
         $this->balance += $event->amount;

--- a/tests/TestClasses/AggregateRoots/StorableEvents/MoneyRemoved.php
+++ b/tests/TestClasses/AggregateRoots/StorableEvents/MoneyRemoved.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class MoneyRemoved extends ShouldBeStored
+{
+    public int $amount;
+
+    public function __construct(int $amount)
+    {
+        $this->amount = $amount;
+    }
+}


### PR DESCRIPTION
This is a proof of concept PR that allows events to be stored concurrently,  avoiding the dreaded `CouldNotPersistAggregate` exception in specific circumstances.

This can be useful to do work in parallel, for example on a queue. Currently, if two jobs process the same aggregate root (AR) simultaneously, one of the jobs will fail because of the `CouldNotPersistAggregate` exception. Or worse, when an AR is being processed in a queued job while a web request is processing the same AR, the user might receive a 500 server error.

A common case we've had is when an AR manages multiple "child" aggregates. For example, an `OrderAggregateRoot` might contain state for multiple order items. We currently cannot process the order items simultaneously because the shared AR creates a bottleneck. The goal of this PR is to allow work to be done concurrently under specific circumstances, while maintaining the current behaviour to avoid ARs to end up in an invalid state.

There are no changes to the current behavior in aggregate roots. If you want to opt into concurrently persisting events, you must replace `recordThat` calls with `recordConcurrently` and `persist` calls with `persistConcurrently`. Ideally this becomes the default behavior in a unified API in the future, but that would be a breaking change that requires a major version tag.

```diff
  class AccountAggregateRoot extends AggregateRoot
  {
      private int $balance = 0;

      public function addMoney(int $amount): void
      {
-         $this->recordThat(new MoneyAdded($amount));
+         $this->recordConcurrently(new MoneyAdded($amount));
      }

      protected function applyMoneyAdded(MoneyAdded $event): void
      {
          $this->balance += $event->amount;
      }
}
```

(In a future major version, I'd rather have an `allowConcurrent` argument on `recordThat`, but that would be a breaking change.)

If multiple processes call `AccountAggregateRoot::addMoney` simultaneously, they'll both be persisted instead of throwing an `CouldNotPersistAggregate` exception.

You may also provide a callback to `recordConcurrently` for additional validation.

```php
class AccountAggregateRoot extends AggregateRoot
{
    // …

    public function removeMoney(int $amount): void
    {
        $this->recordConcurrently(
            new MoneyRemoved($amount),
            function (self $accountAggregateRoot) {
                if ($accountAggregateRoot->balance < $amount) {
                    throw new Exception('Insufficient balance');
                }
            }
        );
    }

    protected function applyMoneyRemoved(MoneyRemoved $event): void
    {
        $this->balance -= $event->amount;
    }
}
```

In this example, `MoneyRemoved` can only be recorded if the balance is high enough. Here's what happens when `persistConcurrently` is called:

- First, we'll run the concurrency check (so you only need to validate your action once)
- We'll attempt to persist the event
- If the `persist` method throws a `CouldNotPersistAggregate` exception, we'll re-retrieve the aggregate root in its latest state and re-record the new events. While we re-record, we'll pass the aggregate root through all concurrency checks again to ensure it still is in a valid state

This way we can allow aggregate roots to be persisted in parallel while guarding against invalid states when needed.