### PR TITLE
Sort projectors by weight when replaying

### DIFF
--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -322,7 +322,8 @@ class Projectionist
         callable $onEventReplayed = null,
         ?string $aggregateUuid = null
     ): void {
-        $projectors = new EventHandlerCollection($projectors);
+        $projectors = (new EventHandlerCollection($projectors))
+            ->sortBy(fn (EventHandler $eventHandler) => $eventHandler->weight ?? 0);
 
         $this->isReplaying = true;
 

--- a/tests/ProjectionistTest.php
+++ b/tests/ProjectionistTest.php
@@ -84,6 +84,28 @@ it('will call projectors ordered by weight', function () {
     ], app(ProjectorWithWeightTestHelper::class)->calledBy);
 });
 
+it('will replay projectors ordered by weight', function () {
+    app()->singleton(ProjectorWithWeightTestHelper::class);
+
+    event(new MoneyAddedEvent($this->account, 1000));
+
+    Projectionist::addProjectors([
+        ProjectorWithHighWeight::class,
+        ProjectorWithoutWeight::class,
+        ProjectorWithNegativeWeight::class,
+        ProjectorWithLowWeight::class,
+    ]);
+
+    Projectionist::replay(Projectionist::getProjectors());
+
+    assertSame([
+        ProjectorWithNegativeWeight::class,
+        ProjectorWithoutWeight::class,
+        ProjectorWithLowWeight::class,
+        ProjectorWithHighWeight::class,
+    ], app(ProjectorWithWeightTestHelper::class)->calledBy);
+});
+
 it('can catch exceptions and still continue calling other projectors', function () {
     $this->setConfig('event-sourcing.catch_exceptions', true);
 


### PR DESCRIPTION
Currently, it is possible to add weights to projectors. This is also documented in: https://spatie.be/docs/laravel-event-sourcing/v7/using-projectors/making-sure-events-get-handled-in-the-right-order#content-tweaking-projector-order

However, the documentation does not mention that weights do not work when replaying events. Yet it can be assumed by default.

This sorting is useful when certain projections depend on others. **For illustration purposes**, here is a simple example:

1. Imagine there are two events `UserCreated` and `UserEmailUpdated`. They are projected with a `UserProjector`.
On every event, the projector class either saves a new user projection or updates the current entry.
Our `users` table, could look something like this:
```
| id  | uuid | email             | 
|-----|------|-------------------|
| 1   | foo  | email@example.com |
| 2   | bar  | test@example.com  |
| ... | ...  | ...               |
```
2. Now, imagine a new business case arrises that requires another projection to keep user email addresses in a structured manner (structured compared to plain event entries). This can be kept in an `emails` table:
```
| id  | user_uuid | email                 |
|-----|-----------|-----------------------|
| 1   | foo       | old-email@example.com |
| 2   | foo       | email@example.com     |
| 3   | bar       | test@example.com      |
| ... | ...       | ...                   |
```

The tricky part is: **the `user_uuid` column in the `emails` table has a foreign key constraint on the `users.uuid` column.**

To keep things tidy, another projector class can be used for these events: `EmailProjector`, which stores new `EmailProjections` and uses the same `UserCreated` and `UserEmailUpdated` events.

Unfortunately, if we were to replay all projectors, the replay would fail. That's because there is a chance that `EmailProjector` will be executed before `UserProjector`. Therefore, the database foreign key constraint would fail.

My proposed changes would help to overcome similar cases.
In addition, it makes the functionality consistent and intuitive - weights matter when dispatching events and when replaying events.