### PR TITLE
Storable event name customization

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -75,7 +75,8 @@
                 "Spatie\\EventSourcing\\EventSourcingServiceProvider"
             ],
             "aliases": {
-                "Projectionist": "Spatie\\EventSourcing\\Facades\\EventSourcing"
+                "EventRegistry": "Spatie\\EventSourcing\\Facades\\EventRegistry",
+                "Projectionist": "Spatie\\EventSourcing\\Facades\\Projectionist"
             }
         }
     },

--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -3,6 +3,14 @@
 return [
 
     /*
+     * These directories will be scanned for storable events. They
+     * will be registered to event registry automatically.
+     */
+    'auto_discover_storable_events' => [
+        app()->path(),
+    ],
+
+    /*
      * These directories will be scanned for projectors and reactors. They
      * will be registered to Projectionist automatically.
      */
@@ -12,33 +20,44 @@ return [
 
     /*
      * This directory will be used as the base path when scanning
-     * for projectors and reactors.
+     * for storable events, projectors and reactors.
      */
     'auto_discover_base_path' => base_path(),
 
     /*
+     * Storable events are type of events being stored in storage repository when they fire.
+     * You can create them by performing `php artisan make:storable-event`.
+     * Similar to Relation::morphMap() you can define which alias responds to which
+     * event class. This allows you to change the namespace or class names
+     * of your events but still handle older events correctly.
+     */
+    'storable_events' => [
+        // 'money-added' => App\StorableEvents\MoneyAddedEvent::class,
+    ],
+
+    /*
      * Projectors are classes that build up projections. You can create them by performing
-     * `php artisan event-sourcing:create-projector`. When not using auto-discovery,
+     * `php artisan make:projector`. When not using auto-discovery,
      * Projectors can be registered in this array or a service provider.
      */
     'projectors' => [
-        // App\Projectors\YourProjector::class
+        // App\Projectors\YourProjector::class,
     ],
 
     /*
      * Reactors are classes that handle side-effects. You can create them by performing
-     * `php artisan event-sourcing:create-reactor`. When not using auto-discovery
+     * `php artisan make:reactor`. When not using auto-discovery,
      * Reactors can be registered in this array or a service provider.
      */
     'reactors' => [
-        // App\Reactors\YourReactor::class
+        // App\Reactors\YourReactor::class,
     ],
 
     /*
      * A queue is used to guarantee that all events get passed to the projectors in
      * the right order. Here you can set of the name of the queue.
      */
-    'queue' => env('EVENT_PROJECTOR_QUEUE_NAME', null),
+    'queue' => env('EVENT_PROJECTOR_QUEUE_NAME'),
 
     /*
      * When a Projector or Reactor throws an exception the event Projectionist can catch it
@@ -81,13 +100,6 @@ return [
      * it should implement \Spatie\EventSourcing\StoredEvents\HandleDomainEventJob.
      */
     'stored_event_job' => Spatie\EventSourcing\StoredEvents\HandleStoredEventJob::class,
-
-    /*
-     * Similar to Relation::morphMap() you can define which alias responds to which
-     * event class. This allows you to change the namespace or class names
-     * of your events but still handle older events correctly.
-     */
-    'event_class_map' => [],
 
     /*
      * This class is responsible for serializing events. By default an event will be serialized

--- a/docs/advanced-usage/using-aliases-for-stored-event-classes.md
+++ b/docs/advanced-usage/using-aliases-for-stored-event-classes.md
@@ -9,12 +9,14 @@ To get around this you can define event class aliases in the `event-sourcing.php
 
 ```php
     /*
+     * Storable events are type of events being stored in storage repository when they fire.
+     * You can create them by performing `php artisan make:storable-event`.
      * Similar to Relation::morphMap() you can define which alias responds to which
-     * event class. This allows you to change the namespace or classnames
+     * event class. This allows you to change the namespace or class names
      * of your events but still handle older events correctly.
      */
-    'event_class_map' => [
-        'money_added' => MoneyAddedEvent::class,
+    'storable_events' => [
+        'money-added' => App\StorableEvents\MoneyAddedEvent::class,
     ],
 ```
 

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -25,39 +25,68 @@ php artisan vendor:publish --provider="Spatie\EventSourcing\EventSourcingService
 This is the default content of the config file that will be published at `config/event-sourcing.php`:
 
 ```php
-use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSourcing\Models\EloquentStoredEvent;use Spatie\EventSourcing\StoredEvents\HandleStoredEventJob;return [
+use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;
+use Spatie\EventSourcing\Models\EloquentStoredEvent;
+use Spatie\EventSourcing\StoredEvents\HandleStoredEventJob;
+
+return [
+
+    /*
+     * These directories will be scanned for storable events. They
+     * will be registered to event registry automatically.
+     */
+    'auto_discover_storable_events' => [
+        app()->path(),
+    ],
 
     /*
      * These directories will be scanned for projectors and reactors. They
-     * will be automatically registered to projectionist automatically.
+     * will be registered to Projectionist automatically.
      */
     'auto_discover_projectors_and_reactors' => [
-        app_path(),
+        app()->path(),
+    ],
+
+    /*
+     * This directory will be used as the base path when scanning
+     * for storable events, projectors and reactors.
+     */
+    'auto_discover_base_path' => base_path(),
+
+    /*
+     * Storable events are type of events being stored in storage repository when they fire.
+     * You can create them by performing `php artisan make:storable-event`.
+     * Similar to Relation::morphMap() you can define which alias responds to which
+     * event class. This allows you to change the namespace or class names
+     * of your events but still handle older events correctly.
+     */
+    'storable_events' => [
+        // 'money-added' => App\StorableEvents\MoneyAddedEvent::class,
     ],
 
     /*
      * Projectors are classes that build up projections. You can create them by performing
-     * `php artisan make:projector`.  When not using auto-discovery
+     * `php artisan make:projector`. When not using auto-discovery,
      * Projectors can be registered in this array or a service provider.
      */
     'projectors' => [
-        // App\Projectors\YourProjector::class
+        // App\Projectors\YourProjector::class,
     ],
 
     /*
-     * Reactors are classes that handle side effects. You can create them by performing
-     * `php artisan make:reactor`. When not using auto-discovery
+     * Reactors are classes that handle side-effects. You can create them by performing
+     * `php artisan make:reactor`. When not using auto-discovery,
      * Reactors can be registered in this array or a service provider.
      */
     'reactors' => [
-        // App\Reactors\YourReactor::class
+        // App\Reactors\YourReactor::class,
     ],
 
     /*
      * A queue is used to guarantee that all events get passed to the projectors in
      * the right order. Here you can set of the name of the queue.
      */
-    'queue' => env('EVENT_PROJECTOR_QUEUE_NAME', null),
+    'queue' => env('EVENT_PROJECTOR_QUEUE_NAME'),
 
     /*
      * When a projector or reactor throws an exception the event projectionist can catch it
@@ -79,13 +108,6 @@ use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSo
      * it should implement \Spatie\EventSourcing\HandleDomainEventJob.
      */
     'stored_event_job' => HandleStoredEventJob::class,
-
-    /*
-     * Similar to Relation::morphMap() you can define which alias responds to which
-     * event class. This allows you to change the namespace or class names
-     * of your events but still handle older events correctly.
-     */
-    'event_class_map' => [],
 
     /*
      * This class is responsible for serializing events. By default an event will be serialized

--- a/src/Attributes/EventAlias.php
+++ b/src/Attributes/EventAlias.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\EventSourcing\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+class EventAlias
+{
+    public function __construct(
+        public string $alias
+    ) {
+    }
+}

--- a/src/Console/CacheStorableEventsCommand.php
+++ b/src/Console/CacheStorableEventsCommand.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\EventSourcing\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Collection;
+use Spatie\EventSourcing\EventRegistry;
+
+class CacheStorableEventsCommand extends Command
+{
+    protected $signature = 'event-sourcing:cache-storable-events';
+
+    protected $description = 'Cache all auto discovered storable events';
+
+    public function handle(EventRegistry $eventRegistry, Filesystem $files): void
+    {
+        $this->info('Caching registered storable events...');
+
+        $eventRegistry->getClassMap()
+            ->pipe(function (Collection $eventClasses) use ($files) {
+                $cachePath = config('event-sourcing.cache_path');
+
+                $files->makeDirectory($cachePath, 0755, true, true);
+
+                $files->put(
+                    $cachePath.'/storable-events.php',
+                    '<?php return '.var_export($eventClasses->toArray(), true).';'
+                );
+            });
+
+        $this->info('All done!');
+    }
+}

--- a/src/Console/ClearCachedStorableEventsCommand.php
+++ b/src/Console/ClearCachedStorableEventsCommand.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\EventSourcing\Console;
+
+use Illuminate\Console\Command;
+use Illuminate\Filesystem\Filesystem;
+
+class ClearCachedStorableEventsCommand extends Command
+{
+    protected $signature = 'event-sourcing:clear-storable-events';
+
+    protected $description = 'Clear cached storable events';
+
+    public function handle(Filesystem $files): void
+    {
+        $files->delete(config('event-sourcing.cache_path').'/storable-events.php');
+
+        $this->info('Cached storable events cleared!');
+    }
+}

--- a/src/Console/ListCommand.php
+++ b/src/Console/ListCommand.php
@@ -5,6 +5,7 @@ namespace Spatie\EventSourcing\Console;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Spatie\EventSourcing\EventHandlers\EventHandler;
+use Spatie\EventSourcing\Facades\EventRegistry;
 use Spatie\EventSourcing\Projectionist;
 
 class ListCommand extends Command
@@ -19,14 +20,14 @@ class ListCommand extends Command
         $projectors = $projectionist->getProjectors();
         $rows = $this->convertEventHandlersToTableRows($projectors);
         count($rows)
-            ? $this->table(['Event', 'Handled by projectors'], $rows)
+            ? $this->table(['Event', 'Alias', 'Handled by projectors'], $rows)
             : $this->warn('No projectors registered');
 
         $this->info('');
-        $projectors = $projectionist->getReactors();
-        $rows = $this->convertEventHandlersToTableRows($projectors);
+        $reactors = $projectionist->getReactors();
+        $rows = $this->convertEventHandlersToTableRows($reactors);
         count($rows)
-            ? $this->table(['Event', 'Handled by reactors'], $rows)
+            ? $this->table(['Event', 'Alias', 'Handled by reactors'], $rows)
             : $this->warn('No reactors registered');
     }
 
@@ -44,9 +45,11 @@ class ListCommand extends Command
             }, []);
 
         return collect($events)
-            ->map(function (array $eventHandlers, string $eventClass) {
-                return [$eventClass, implode(PHP_EOL, collect($eventHandlers)->sort()->toArray())];
-            })
+            ->map(fn (array $eventHandlers, string $eventClass) => [
+                $eventClass,
+                EventRegistry::getAlias($eventClass),
+                implode(PHP_EOL, collect($eventHandlers)->sort()->toArray()),
+            ])
             ->sort()
             ->values()
             ->toArray();

--- a/src/EventRegistry.php
+++ b/src/EventRegistry.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Spatie\EventSourcing;
+
+use Illuminate\Support\Collection;
+use Spatie\EventSourcing\Exceptions\InvalidStorableEvent;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class EventRegistry
+{
+    protected Collection $classMap;
+
+    public function __construct(array $eventClasses = [])
+    {
+        $this->classMap = new Collection();
+
+        $this->addEventClasses($eventClasses);
+    }
+
+    public function addEventClass(string $eventClass, string $alias = null): static
+    {
+        if (! is_subclass_of($eventClass, ShouldBeStored::class)) {
+            throw InvalidStorableEvent::notAStorableEventClassName($eventClass);
+        }
+
+        if (! $this->classMap->containsStrict($eventClass)) {
+            $this->classMap->put($eventClass::eventName($alias), $eventClass);
+        }
+
+        return $this;
+    }
+
+    public function addEventClasses(array $eventClasses): static
+    {
+        foreach ($eventClasses as $alias => $eventClass) {
+            $this->addEventClass($eventClass, is_int($alias) ? null : $alias);
+        }
+
+        return $this;
+    }
+
+    public function getEventClass(string $alias): string
+    {
+        return $this->classMap->get($alias, $alias);
+    }
+
+    public function getAlias(string $eventClass): string
+    {
+        return $this->classMap->search($eventClass, true) ?: $eventClass;
+    }
+
+    public function setClassMap(array $classMap): static
+    {
+        $this->classMap = new Collection($classMap);
+
+        return $this;
+    }
+
+    public function getClassMap(): Collection
+    {
+        return $this->classMap;
+    }
+}

--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -87,7 +87,7 @@ class EventSourcingServiceProvider extends PackageServiceProvider
         $this->app->bind(EventSerializer::class, config('event-sourcing.event_serializer'));
     }
 
-    public function discoverStorableEvents()
+    protected function discoverStorableEvents()
     {
         /** @var EventRegistry $eventRegistry */
         $eventRegistry = app(EventRegistry::class);

--- a/src/Exceptions/InvalidStorableEvent.php
+++ b/src/Exceptions/InvalidStorableEvent.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\EventSourcing\Exceptions;
+
+use Exception;
+
+class InvalidStorableEvent extends Exception
+{
+    public static function notAStorableEventClassName(string $className): self
+    {
+        return new static('`'.$className.'` must implement Spatie\EventSourcing\StoredEvents\ShouldBeStored');
+    }
+}

--- a/src/Facades/EventRegistry.php
+++ b/src/Facades/EventRegistry.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Spatie\EventSourcing\Facades;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Facade;
+use Spatie\EventSourcing\EventRegistry as Registry;
+
+/**
+ * @method static Registry addEventClass(string $eventClass, string $alias = null)
+ * @method static Registry addEventClasses(array $eventClasses)
+ * @method static string getEventClass(string $alias)
+ * @method static string getAlias(string $eventClass)
+ * @method static Registry setClassMap(array $classMap)
+ * @method static Collection getClassMap()
+ */
+class EventRegistry extends Facade
+{
+    protected static function getFacadeAccessor(): string
+    {
+        return 'event-registry';
+    }
+}

--- a/src/Facades/EventRegistry.php
+++ b/src/Facades/EventRegistry.php
@@ -13,6 +13,8 @@ use Spatie\EventSourcing\EventRegistry as Registry;
  * @method static string getAlias(string $eventClass)
  * @method static Registry setClassMap(array $classMap)
  * @method static Collection getClassMap()
+ *
+ * @see \Spatie\EventSourcing\EventRegistry
  */
 class EventRegistry extends Facade
 {

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -8,6 +8,7 @@ use Illuminate\Support\LazyCollection;
 use Spatie\EventSourcing\AggregateRoots\Exceptions\InvalidEloquentStoredEventModel;
 use Spatie\EventSourcing\Enums\MetaData;
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
+use Spatie\EventSourcing\Facades\EventRegistry;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEventQueryBuilder;
 use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
@@ -87,7 +88,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
             'aggregate_uuid' => $uuid,
             'aggregate_version' => $event->aggregateRootVersion(),
             'event_version' => $event->eventVersion(),
-            'event_class' => $this->getEventClass(get_class($event)),
+            'event_class' => EventRegistry::getAlias(get_class($event)),
             'meta_data' => json_encode($event->metaData() + [
                 MetaData::CREATED_AT => $createdAt->toDateTimeString(),
             ]),
@@ -125,17 +126,6 @@ class EloquentStoredEventRepository implements StoredEventRepository
         $eloquentStoredEvent->update($storedEvent->toArray());
 
         return $eloquentStoredEvent->toStoredEvent();
-    }
-
-    private function getEventClass(string $class): string
-    {
-        $map = config('event-sourcing.event_class_map', []);
-
-        if (! empty($map) && in_array($class, $map)) {
-            return array_search($class, $map, true);
-        }
-
-        return $class;
     }
 
     public function getLatestAggregateVersion(string $aggregateUuid): int

--- a/src/Support/DiscoverStorableEvents.php
+++ b/src/Support/DiscoverStorableEvents.php
@@ -3,14 +3,14 @@
 namespace Spatie\EventSourcing\Support;
 
 use Illuminate\Support\Collection;
-use Spatie\EventSourcing\EventHandlers\EventHandler;
-use Spatie\EventSourcing\Projectionist;
+use Spatie\EventSourcing\EventRegistry;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 use SplFileInfo;
 use Symfony\Component\Finder\Finder;
 
-class DiscoverEventHandlers extends DiscoveryHelper
+class DiscoverStorableEvents extends DiscoveryHelper
 {
-    public function addToProjectionist(Projectionist $projectionist)
+    public function addToEventRegistry(EventRegistry $eventRegistry)
     {
         if (empty($this->directories)) {
             return;
@@ -21,9 +21,9 @@ class DiscoverEventHandlers extends DiscoveryHelper
         return collect($files)
             ->reject(fn (SplFileInfo $file) => in_array($file->getPathname(), $this->ignoredFiles))
             ->map(fn (SplFileInfo $file) => $this->fullyQualifiedClassNameFromFile($file))
-            ->filter(fn (string $eventHandlerClass) => is_subclass_of($eventHandlerClass, EventHandler::class))
-            ->pipe(function (Collection $eventHandlers) use ($projectionist) {
-                $projectionist->addEventHandlers($eventHandlers->toArray());
+            ->filter(fn (string $eventClass) => is_subclass_of($eventClass, ShouldBeStored::class))
+            ->pipe(function (Collection $eventClasses) use ($eventRegistry) {
+                $eventRegistry->addEventClasses($eventClasses->toArray());
             });
     }
 }

--- a/src/Support/DiscoveryHelper.php
+++ b/src/Support/DiscoveryHelper.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Spatie\EventSourcing\Support;
+
+use Illuminate\Support\Str;
+use SplFileInfo;
+
+abstract class DiscoveryHelper
+{
+    protected array $directories = [];
+
+    protected string $basePath = '';
+
+    protected string $rootNamespace = '';
+
+    protected array $ignoredFiles = [];
+
+    public function __construct()
+    {
+        $this->basePath = app()->path();
+    }
+
+    public function within(array $directories): self
+    {
+        $this->directories = $directories;
+
+        return $this;
+    }
+
+    public function useBasePath(string $basePath): self
+    {
+        $this->basePath = $basePath;
+
+        return $this;
+    }
+
+    public function useRootNamespace(string $rootNamespace): self
+    {
+        $this->rootNamespace = $rootNamespace;
+
+        return $this;
+    }
+
+    public function ignoringFiles(array $ignoredFiles): self
+    {
+        $this->ignoredFiles = $ignoredFiles;
+
+        return $this;
+    }
+
+    protected function fullyQualifiedClassNameFromFile(SplFileInfo $file): string
+    {
+        $class = trim(Str::replaceFirst($this->basePath, '', $file->getRealPath()), DIRECTORY_SEPARATOR);
+
+        $class = str_replace(
+            [DIRECTORY_SEPARATOR, 'App\\'],
+            ['\\', app()->getNamespace()],
+            ucfirst(Str::replaceLast('.php', '', $class))
+        );
+
+        return $this->rootNamespace.$class;
+    }
+}

--- a/tests/Console/CacheStorableEventsCommandTest.php
+++ b/tests/Console/CacheStorableEventsCommandTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\Console;
+
+use Spatie\EventSourcing\EventRegistry;
+use Spatie\EventSourcing\Tests\TestClasses\Events\TestEvent;
+
+use function Spatie\Snapshots\assertMatchesSnapshot;
+
+beforeEach(function () {
+    $this->eventRegistry = app(EventRegistry::class);
+});
+
+it('can cache the registered storable events', function () {
+    $this->eventRegistry->addEventClass(TestEvent::class);
+
+    $this->artisan('event-sourcing:cache-storable-events')->assertExitCode(0);
+
+    assertMatchesSnapshot(file_get_contents(config('event-sourcing.cache_path').'/storable-events.php'));
+});

--- a/tests/Console/ClearStorableEventsCommandTest.php
+++ b/tests/Console/ClearStorableEventsCommandTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\Console;
+
+use function PHPUnit\Framework\assertFileDoesNotExist;
+use function PHPUnit\Framework\assertFileExists;
+
+use Spatie\EventSourcing\EventRegistry;
+use Spatie\EventSourcing\Tests\TestClasses\Events\TestEvent;
+
+beforeEach(function () {
+    $this->eventRegistry = app(EventRegistry::class);
+});
+
+it('can clear the registered storable events', function () {
+    $this->eventRegistry->addEventClass(TestEvent::class);
+
+    $this->artisan('event-sourcing:cache-storable-events')->assertExitCode(0);
+
+    assertFileExists(config('event-sourcing.cache_path').'/storable-events.php');
+
+    $this->artisan('event-sourcing:clear-storable-events')->assertExitCode(0);
+
+    assertFileDoesNotExist(config('event-sourcing.cache_path').'/storable-events.php');
+});

--- a/tests/DiscoversEventHandlersTest.php
+++ b/tests/DiscoversEventHandlersTest.php
@@ -15,11 +15,6 @@ use Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverEventHandlers\TestProject
 use Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverEventHandlers\TestQueuedProjector;
 use Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverEventHandlers\TestReactor;
 
-function getDiscoveryBasePath(): string
-{
-    return realpath(test()->pathToTests().'/../');
-}
-
 it('can get all classes that have event handlers', function () {
     /** @var \Spatie\EventSourcing\Projectionist $projectionist */
     $projectionist = app(Projectionist::class);
@@ -28,7 +23,7 @@ it('can get all classes that have event handlers', function () {
 
     (new DiscoverEventHandlers())
         ->within([__DIR__.'/TestClasses/AutoDiscoverEventHandlers'])
-        ->useBasePath(getDiscoveryBasePath())
+        ->useBasePath(realpath(test()->pathToTests().'/../'))
         ->useRootNamespace('Spatie\EventSourcing\\')
         ->ignoringFiles(Composer::getAutoloadedFiles($pathToComposerJson))
 

--- a/tests/DiscoversStorableEventsTest.php
+++ b/tests/DiscoversStorableEventsTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests;
+
+use function PHPUnit\Framework\assertEqualsCanonicalizing;
+
+use Spatie\EventSourcing\EventRegistry;
+use Spatie\EventSourcing\Support\Composer;
+use Spatie\EventSourcing\Support\DiscoverStorableEvents;
+use Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverStorableEvents\Subdirectory\TestStorableEventInSubdirectory;
+use Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverStorableEvents\TestStorableEvent;
+
+it('can get all storable event classes', function () {
+    /** @var \Spatie\EventSourcing\EventRegistry $eventRegistry */
+    $eventRegistry = app(EventRegistry::class);
+
+    $pathToComposerJson = __DIR__.'/../composer.json';
+
+    (new DiscoverStorableEvents())
+        ->within([__DIR__.'/TestClasses/AutoDiscoverStorableEvents'])
+        ->useBasePath(realpath(test()->pathToTests().'/../'))
+        ->useRootNamespace('Spatie\EventSourcing\\')
+        ->ignoringFiles(Composer::getAutoloadedFiles($pathToComposerJson))
+
+        ->addToEventRegistry($eventRegistry);
+
+    $registeredStorableEvents = $eventRegistry
+        ->getClassMap()
+        ->values()
+        ->toArray();
+
+    assertEqualsCanonicalizing([
+        TestStorableEvent::class,
+        TestStorableEventInSubdirectory::class,
+    ], $registeredStorableEvents);
+});

--- a/tests/EventRegistryTest.php
+++ b/tests/EventRegistryTest.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests;
+
+use function PHPUnit\Framework\assertEquals;
+use function Spatie\Snapshots\assertMatchesSnapshot;
+
+use Spatie\EventSourcing\Facades\EventRegistry;
+use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithAlias;
+use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithCustomAlias;
+use Spatie\EventSourcing\Tests\TestClasses\Events\TestEvent;
+
+it('sets event class map as is', function () {
+    EventRegistry::setClassMap($classMap = [
+        'entry-1' => TestEvent::class,
+        'entry-2' => EventWithAlias::class,
+        'entry-3' => EventWithCustomAlias::class,
+    ]);
+
+    assertEquals($classMap, EventRegistry::getClassMap()->all());
+});
+
+it('passes through alias if corresponding event class has not been found in registry', function () {
+    $eventClass = EventRegistry::getEventClass('event-alias');
+    assertEquals('event-alias', $eventClass);
+});
+
+it('passes through event class if corresponding alias has not been found in registry', function () {
+    $alias = EventRegistry::getAlias(TestEvent::class);
+    assertEquals(TestEvent::class, $alias);
+
+    $alias = EventRegistry::getAlias(EventWithAlias::class);
+    assertEquals(EventWithAlias::class, $alias);
+});
+
+it('will set the default alias based on class name while adding event to the registry', function () {
+    EventRegistry::addEventClass(TestEvent::class);
+
+    $eventClass = EventRegistry::getEventClass('test-event');
+    assertEquals(TestEvent::class, $eventClass);
+
+    $alias = EventRegistry::getAlias(TestEvent::class);
+    assertEquals('test-event', $alias);
+});
+
+it('will set the custom alias while adding event to the registry', function () {
+    EventRegistry::addEventClass(TestEvent::class, 'event-with-custom-alias');
+
+    $eventClass = EventRegistry::getEventClass('event-with-custom-alias');
+    assertEquals(TestEvent::class, $eventClass);
+
+    $alias = EventRegistry::getAlias(TestEvent::class);
+    assertEquals('event-with-custom-alias', $alias);
+});
+
+it('will set the alias from attribute while adding event to the registry', function () {
+    EventRegistry::addEventClass(EventWithAlias::class);
+
+    $eventClass = EventRegistry::getEventClass('event-with-alias-from-attribute');
+    assertEquals(EventWithAlias::class, $eventClass);
+
+    $alias = EventRegistry::getAlias(EventWithAlias::class);
+    assertEquals('event-with-alias-from-attribute', $alias);
+});
+
+it('will prioritize custom alias over alias defined in attribute', function () {
+    EventRegistry::addEventClass(EventWithAlias::class, 'event-with-custom-alias');
+
+    $eventClass = EventRegistry::getEventClass('event-with-custom-alias');
+    assertEquals(EventWithAlias::class, $eventClass);
+
+    $alias = EventRegistry::getAlias(EventWithAlias::class);
+    assertEquals('event-with-custom-alias', $alias);
+});
+
+it('will set the alias from eventName method while adding event to the registry', function () {
+    EventRegistry::addEventClass(EventWithCustomAlias::class);
+
+    $eventClass = EventRegistry::getEventClass('event-with-alias-from-method');
+    assertEquals(EventWithCustomAlias::class, $eventClass);
+
+    $alias = EventRegistry::getAlias(EventWithCustomAlias::class);
+    assertEquals('event-with-alias-from-method', $alias);
+});
+
+it('wont fall back to default name resolution logic unless instructed explicitly', function () {
+    EventRegistry::addEventClass(EventWithCustomAlias::class, 'event-with-custom-alias');
+
+    $eventClass = EventRegistry::getEventClass('event-with-alias-from-method');
+    assertEquals(EventWithCustomAlias::class, $eventClass);
+
+    $alias = EventRegistry::getAlias(EventWithCustomAlias::class);
+    assertEquals('event-with-alias-from-method', $alias);
+});
+
+it('wont override already existing entry', function () {
+    EventRegistry::addEventClass(TestEvent::class, 'alias-1');
+    EventRegistry::addEventClass(TestEvent::class, 'alias-2');
+
+    $eventClass = EventRegistry::getEventClass('alias-1');
+    assertEquals(TestEvent::class, $eventClass);
+
+    $eventClass = EventRegistry::getEventClass('alias-2');
+    assertEquals('alias-2', $eventClass);
+
+    $alias = EventRegistry::getAlias(TestEvent::class);
+    assertEquals('alias-1', $alias);
+});
+
+it('can register multiple event classes at once', function () {
+    EventRegistry::addEventClasses([
+        'custom-alias' => TestEvent::class,
+        EventWithAlias::class,
+        'this-record-wont-add' => EventWithAlias::class,
+        'this-alias-wont-be-used' => EventWithCustomAlias::class,
+    ]);
+
+    $classMap = EventRegistry::getClassMap()->all();
+    assertMatchesSnapshot($classMap);
+});

--- a/tests/EventRegistryTest.php
+++ b/tests/EventRegistryTest.php
@@ -5,7 +5,9 @@ namespace Spatie\EventSourcing\Tests;
 use function PHPUnit\Framework\assertEquals;
 use function Spatie\Snapshots\assertMatchesSnapshot;
 
+use Spatie\EventSourcing\Exceptions\InvalidStorableEvent;
 use Spatie\EventSourcing\Facades\EventRegistry;
+use Spatie\EventSourcing\Tests\TestClasses\Events\DoNotStoreThisEvent;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithAlias;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithCustomAlias;
 use Spatie\EventSourcing\Tests\TestClasses\Events\TestEvent;
@@ -32,6 +34,10 @@ it('passes through event class if corresponding alias has not been found in regi
     $alias = EventRegistry::getAlias(EventWithAlias::class);
     assertEquals(EventWithAlias::class, $alias);
 });
+
+it('will throw an exception if event class does not extend ShouldBeStored', function () {
+    EventRegistry::addEventClass(DoNotStoreThisEvent::class);
+})->throws(InvalidStorableEvent::class);
 
 it('will set the default alias based on class name while adding event to the registry', function () {
     EventRegistry::addEventClass(TestEvent::class);

--- a/tests/EventSubscriberTest.php
+++ b/tests/EventSubscriberTest.php
@@ -75,7 +75,7 @@ it('will log events that implement ShouldBeStored with an alias', function () {
 
     $storedEvent = EloquentStoredEvent::first();
 
-    $this->assertDatabaseHas('stored_events', ['event_class' => 'event_with_alias']);
+    $this->assertDatabaseHas('stored_events', ['event_class' => 'event-with-alias-from-attribute']);
 
     assertInstanceOf(EventWithAlias::class, $storedEvent->event);
 });

--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -15,6 +15,7 @@ use function PHPUnit\Framework\assertTrue;
 
 use Spatie\EventSourcing\Enums\MetaData;
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
+use Spatie\EventSourcing\Facades\EventRegistry;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\StoredEvents\Exceptions\InvalidStoredEvent;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
@@ -52,8 +53,8 @@ it('will throw a human readable exception when the event couldnt be deserialized
     EloquentStoredEvent::first()->toStoredEvent();
 })->throws(InvalidStoredEvent::class);
 
-it('will store the alias when a classname is found in the event class map', function () {
-    $this->setConfig('event-sourcing.event_class_map', [
+it('will store the alias when a classname is found in the event registry', function () {
+    EventRegistry::addEventClasses([
         'money_added' => MoneyAddedEvent::class,
     ]);
 
@@ -68,7 +69,7 @@ it('allows to modify metadata with offset set in eloquent model', function () {
         $event->meta_data->set('ip', '127.0.0.1');
     });
 
-    $this->setConfig('event-sourcing.event_class_map', [
+    EventRegistry::addEventClasses([
         'money_added' => MoneyAddedEvent::class,
     ]);
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,6 +25,7 @@ abstract class TestCase extends Orchestra
 
         FakeUuid::reset();
 
+        $this->artisan('event-sourcing:clear-storable-events');
         $this->artisan('event-sourcing:clear-event-handlers');
     }
 

--- a/tests/TestClasses/AutoDiscoverEventHandlers/functions.php
+++ b/tests/TestClasses/AutoDiscoverEventHandlers/functions.php
@@ -1,5 +1,7 @@
 <?php
 
-function aTestFunction()
-{
+if (! function_exists('aTestFunction')) {
+    function aTestFunction()
+    {
+    }
 }

--- a/tests/TestClasses/AutoDiscoverStorableEvents/OtherClass.php
+++ b/tests/TestClasses/AutoDiscoverStorableEvents/OtherClass.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverStorableEvents;
+
+class OtherClass
+{
+}

--- a/tests/TestClasses/AutoDiscoverStorableEvents/Subdirectory/OtherClassInSubdirectory.php
+++ b/tests/TestClasses/AutoDiscoverStorableEvents/Subdirectory/OtherClassInSubdirectory.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverStorableEvents\Subdirectory;
+
+class OtherClassInSubdirectory
+{
+}

--- a/tests/TestClasses/AutoDiscoverStorableEvents/Subdirectory/TestStorableEventInSubdirectory.php
+++ b/tests/TestClasses/AutoDiscoverStorableEvents/Subdirectory/TestStorableEventInSubdirectory.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverStorableEvents\Subdirectory;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class TestStorableEventInSubdirectory extends ShouldBeStored
+{
+}

--- a/tests/TestClasses/AutoDiscoverStorableEvents/TestStorableEvent.php
+++ b/tests/TestClasses/AutoDiscoverStorableEvents/TestStorableEvent.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverStorableEvents;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class TestStorableEvent extends ShouldBeStored
+{
+}

--- a/tests/TestClasses/AutoDiscoverStorableEvents/functions.php
+++ b/tests/TestClasses/AutoDiscoverStorableEvents/functions.php
@@ -1,0 +1,5 @@
+<?php
+
+function aTestFunction()
+{
+}

--- a/tests/TestClasses/AutoDiscoverStorableEvents/functions.php
+++ b/tests/TestClasses/AutoDiscoverStorableEvents/functions.php
@@ -1,5 +1,7 @@
 <?php
 
-function aTestFunction()
-{
+if (! function_exists('aTestFunction')) {
+    function aTestFunction()
+    {
+    }
 }

--- a/tests/TestClasses/Events/EventWithAlias.php
+++ b/tests/TestClasses/Events/EventWithAlias.php
@@ -5,7 +5,7 @@ namespace Spatie\EventSourcing\Tests\TestClasses\Events;
 use Spatie\EventSourcing\Attributes\EventAlias;
 use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
 
-#[EventAlias('event_with_alias')]
+#[EventAlias('event-with-alias-from-attribute')]
 class EventWithAlias extends ShouldBeStored
 {
 }

--- a/tests/TestClasses/Events/EventWithAlias.php
+++ b/tests/TestClasses/Events/EventWithAlias.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Events;
+
+use Spatie\EventSourcing\Attributes\EventAlias;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+#[EventAlias('event_with_alias')]
+class EventWithAlias extends ShouldBeStored
+{
+}

--- a/tests/TestClasses/Events/EventWithCustomAlias.php
+++ b/tests/TestClasses/Events/EventWithCustomAlias.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Events;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class EventWithCustomAlias extends ShouldBeStored
+{
+    public static function eventName(string $mappedAlias = null): string
+    {
+        return 'event-with-alias-from-method';
+    }
+}

--- a/tests/__snapshots__/CacheStorableEventsCommandTest__it_can_cache_the_registered_storable_events__1.txt
+++ b/tests/__snapshots__/CacheStorableEventsCommandTest__it_can_cache_the_registered_storable_events__1.txt
@@ -1,0 +1,3 @@
+<?php return array (
+  'Spatie\\EventSourcing\\Tests\\TestClasses\\Events\\TestEvent' => 'Spatie\\EventSourcing\\Tests\\TestClasses\\Events\\TestEvent',
+);

--- a/tests/__snapshots__/CacheStorableEventsCommandTest__it_can_cache_the_registered_storable_events__1.txt
+++ b/tests/__snapshots__/CacheStorableEventsCommandTest__it_can_cache_the_registered_storable_events__1.txt
@@ -1,3 +1,3 @@
 <?php return array (
-  'Spatie\\EventSourcing\\Tests\\TestClasses\\Events\\TestEvent' => 'Spatie\\EventSourcing\\Tests\\TestClasses\\Events\\TestEvent',
+  'test-event' => 'Spatie\\EventSourcing\\Tests\\TestClasses\\Events\\TestEvent',
 );

--- a/tests/__snapshots__/EventRegistryTest__it_can_register_multiple_event_classes_at_once__1.yml
+++ b/tests/__snapshots__/EventRegistryTest__it_can_register_multiple_event_classes_at_once__1.yml
@@ -1,0 +1,3 @@
+custom-alias: Spatie\EventSourcing\Tests\TestClasses\Events\TestEvent
+event-with-alias-from-attribute: Spatie\EventSourcing\Tests\TestClasses\Events\EventWithAlias
+event-with-alias-from-method: Spatie\EventSourcing\Tests\TestClasses\Events\EventWithCustomAlias


### PR DESCRIPTION
I'd like to give a fresh look at a problem discussed in PR #394.
First of all, I'd like to thank @karkowg for his PR (which my PR partially based on) and @sebastiandedeyne for his ideas.

Nevertheless, the main issue which prompted me to create new PR is that `get_declared_classes` function, which used in #394, does not guarantee that every event extending `ShouldBeStored` class will be listed and therefore included into the dictionary.
Alternatively, I'd try to use approach used by event handlers, i.e. (optional) cacheable class discovery with fallback to manually listed events in config file. This is still completely optional - if discovery is disabled and events are not listed manually within `storable_events` key in config file, then events will be saved to storage with their respective class names.

`ShouldBeStored` base class now have static `eventName` method, which is somewhat opinionated😅, but as it's easily overridden in your events' base class, I think it's not the problem. The default implementation looks for the name in the following order:
- mapped name from config file
- alias defined with `EventAlias` attribute
- kebabized classname (or maybe better just FQCN?)

As events in my project are broadcasted, I found it pretty useful, to implement `broadcastAs` method simply as:
```php
public function broadcastAs(): string
{
    return static::eventName();
}
```

Some other changes:
- Added `event-sourcing:cache-storable-events` and `event-sourcing:clear-storable-events` commands
- `event-sourcing:list` command now also displays event aliases
- class discovery logic partially extracted from `DiscoverEventHandlers` into new `DiscoveryHelper` abstract class
- `event_class_map` entry in config file renamed to `storable_events` to better reflect its purpose - now it is not necessarily a map, it may as well be just listing of event classes or mix of both (backward compatibility preserved)