### PR TITLE
Ignore abstract event handlers

### DIFF
--- a/src/Support/DiscoverEventHandlers.php
+++ b/src/Support/DiscoverEventHandlers.php
@@ -4,6 +4,7 @@ namespace Spatie\EventSourcing\Support;
 
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
+use ReflectionClass;
 use Spatie\EventSourcing\EventHandlers\EventHandler;
 use Spatie\EventSourcing\Projectionist;
 use SplFileInfo;
@@ -64,6 +65,7 @@ class DiscoverEventHandlers
             ->reject(fn (SplFileInfo $file) => in_array($file->getPathname(), $this->ignoredFiles))
             ->map(fn (SplFileInfo $file) => $this->fullQualifiedClassNameFromFile($file))
             ->filter(fn (string $eventHandlerClass) => is_subclass_of($eventHandlerClass, EventHandler::class))
+            ->filter(fn (string $eventHandlerClass) => (new ReflectionClass($eventHandlerClass))->isInstantiable())
             ->pipe(function (Collection $eventHandlers) use ($projectionist) {
                 $projectionist->addEventHandlers($eventHandlers->toArray());
             });

--- a/tests/TestClasses/AutoDiscoverEventHandlers/AbstractProjector.php
+++ b/tests/TestClasses/AutoDiscoverEventHandlers/AbstractProjector.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverEventHandlers;
+
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
+
+abstract class AbstractProjector extends Projector
+{
+}

--- a/tests/TestClasses/AutoDiscoverEventHandlers/AbstractReactor.php
+++ b/tests/TestClasses/AutoDiscoverEventHandlers/AbstractReactor.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AutoDiscoverEventHandlers;
+
+use Spatie\EventSourcing\EventHandlers\Reactors\Reactor;
+
+abstract class AbstractReactor extends Reactor
+{
+}


### PR DESCRIPTION
This PR filters out abstract projectors and reactors, so that application code can use abstract subclasses.