### PR TITLE
Support interfaces in aggregate root apply methods

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -256,7 +256,7 @@ abstract class AggregateRoot
             ->public()
             ->protected()
             ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply', 'tap']))
-            ->acceptsTypes([$event::class])
+            ->accepts($event)
             ->all()
             ->each(fn (Method $method) => $this->{$method->getName()}($event));
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -258,7 +258,9 @@ abstract class AggregateRoot
             ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply', 'tap']))
             ->accepts($event)
             ->all()
-            ->each(fn (Method $method) => $this->{$method->getName()}($event));
+            ->each(function (Method $method) use ($event) {
+                return $this->{$method->getName()}($event);
+            });
 
         $this->appliedEvents[] = $event;
 


### PR DESCRIPTION
There's a subtle difference between how aggregate roots discover handler methods versus how interfaces & projectors do. Because of this, type hinting an interface implemented on an event works in projectors & reactors, but not aggregate roots.

This PR changes `AggregateRoot::apply` to be consistent with `HandlesEvents::handle`.