### PR TITLE
Added an extra rejection to prevent events being passed to invalid handlers

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -256,6 +256,7 @@ abstract class AggregateRoot
             ->public()
             ->protected()
             ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply', 'tap']))
+            ->reject(fn (Method $method) => $method->accepts(0))
             ->accepts($event)
             ->all()
             ->each(function (Method $method) use ($event) {

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -73,6 +73,7 @@ abstract class AggregateRoot
             ->public()
             ->protected()
             ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply', 'tap']))
+            ->reject(fn (Method $method) => $method->accepts(null))
             ->accepts($command)
             ->first()
         ) {
@@ -86,6 +87,7 @@ abstract class AggregateRoot
                 ->public()
                 ->protected()
                 ->reject(fn (Method $method) => in_array($method->getName(), ['recordThat', 'apply', 'tap']))
+                ->reject(fn (Method $method) => $method->accepts(null))
                 ->accepts($command)
                 ->first();
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -256,7 +256,7 @@ abstract class AggregateRoot
             ->public()
             ->protected()
             ->reject(fn (Method $method) => in_array($method->getName(), ['handleCommand', 'recordThat', 'apply', 'tap']))
-            ->reject(fn (Method $method) => $method->accepts(0))
+            ->reject(fn (Method $method) => $method->accepts(null))
             ->accepts($event)
             ->all()
             ->each(function (Method $method) use ($event) {

--- a/src/EventHandlers/AppliesEvents.php
+++ b/src/EventHandlers/AppliesEvents.php
@@ -26,6 +26,7 @@ trait AppliesEvents
             ->public()
             ->protected()
             ->reject(fn (Method $method) => in_array($method->getName(), ['apply', 'recordThat']))
+            ->reject(fn (Method $method) => $method->accepts(null))
             ->accepts($event)
             ->all()
             ->each(

--- a/src/EventHandlers/HandlesEvents.php
+++ b/src/EventHandlers/HandlesEvents.php
@@ -47,6 +47,7 @@ trait HandlesEvents
         return Handlers::new($this)
             ->public()
             ->protected()
+            ->reject(fn (Method $method) => $method->accepts(null))
             ->all()
             ->groupBy(fn (Method $method) => $method->getTypes()->first()?->getName())
             ->filter(function (Collection $group, string $key) {

--- a/src/EventHandlers/HandlesEvents.php
+++ b/src/EventHandlers/HandlesEvents.php
@@ -16,6 +16,7 @@ trait HandlesEvents
         return Handlers::new($this)
             ->public()
             ->protected()
+            ->reject(fn (Method $method) => $method->accepts(null))
             ->accepts($storedEvent->event)
             ->all()
             ->isNotEmpty();
@@ -28,6 +29,7 @@ trait HandlesEvents
         Handlers::new($this)
             ->public()
             ->protected()
+            ->reject(fn (Method $method) => $method->accepts(null))
             ->accepts($event)
             ->all()
             ->each(function (Method $method) use ($event) {

--- a/tests/AggregateRootTest.php
+++ b/tests/AggregateRootTest.php
@@ -29,6 +29,7 @@ use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Projectors\AccountProj
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Reactors\DoubleBalanceReactor;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\Reactors\SendMailReactor;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyIncremented;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyMultiplied;
 use Spatie\EventSourcing\Tests\TestClasses\FakeUuid;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
@@ -242,6 +243,13 @@ it('should replay all events with the stored event repository specified when ret
 it('should apply a recorded event immediately', function () {
     $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid);
     $aggregateRoot->addMoney(123);
+
+    assertEquals(123, $aggregateRoot->balance);
+});
+
+it('should apply to aggregate root event handlers using interfaces', function () {
+    $aggregateRoot = AccountAggregateRoot::retrieve($this->aggregateUuid);
+    $aggregateRoot->recordThat(new MoneyIncremented(123));
 
     assertEquals(123, $aggregateRoot->balance);
 });

--- a/tests/AggregateRoots/CommandHandlerTest.php
+++ b/tests/AggregateRoots/CommandHandlerTest.php
@@ -16,7 +16,8 @@ beforeAll(function () {
     class AddItem
     {
         public function __construct(
-            #[AggregateUuid] public string $cartUuid,
+            #[AggregateUuid]
+            public string $cartUuid,
             public string $name
         ) {
         }
@@ -26,7 +27,8 @@ beforeAll(function () {
     class ClearCart
     {
         public function __construct(
-            #[AggregateUuid] public string $cartUuid
+            #[AggregateUuid]
+            public string $cartUuid
         ) {
         }
     }

--- a/tests/Commands/CommandBusTest.php
+++ b/tests/Commands/CommandBusTest.php
@@ -22,7 +22,8 @@ beforeAll(function () {
     class AddItem
     {
         public function __construct(
-            #[AggregateUuid] public string $cartUuid,
+            #[AggregateUuid]
+            public string $cartUuid,
             public string $name
         ) {
         }

--- a/tests/TestClasses/AggregateRoots/AccountAggregateRoot.php
+++ b/tests/TestClasses/AggregateRoots/AccountAggregateRoot.php
@@ -2,8 +2,10 @@
 
 namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots;
 
+use Exception;
 use Spatie\EventSourcing\AggregateRoots\AggregateRoot;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAddedInterface;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyMultiplied;
 
 class AccountAggregateRoot extends AggregateRoot
@@ -38,7 +40,7 @@ class AccountAggregateRoot extends AggregateRoot
         return $this;
     }
 
-    protected function applyMoneyAdded(MoneyAdded $event)
+    protected function applyMoneyAdded(MoneyAdded|MoneyAddedInterface $event)
     {
         $this->balance += $event->amount;
     }
@@ -46,5 +48,15 @@ class AccountAggregateRoot extends AggregateRoot
     public function applyMoneyMultiplied(MoneyMultiplied $event)
     {
         $this->balance = $this->math->multiply($this->balance, $event->amount);
+    }
+
+    public function mixedMethod($param): void
+    {
+        throw new Exception("Method should not be called by apply()");
+    }
+
+    public function variadicMethod(...$param): void
+    {
+        throw new Exception("Method should not be called by apply()");
     }
 }

--- a/tests/TestClasses/AggregateRoots/StorableEvents/MoneyAddedInterface.php
+++ b/tests/TestClasses/AggregateRoots/StorableEvents/MoneyAddedInterface.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents;
+
+interface MoneyAddedInterface
+{
+}

--- a/tests/TestClasses/AggregateRoots/StorableEvents/MoneyIncremented.php
+++ b/tests/TestClasses/AggregateRoots/StorableEvents/MoneyIncremented.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class MoneyIncremented extends ShouldBeStored implements MoneyAddedInterface
+{
+    public int $amount;
+
+    public function __construct(int $amount)
+    {
+        $this->amount = $amount;
+    }
+}


### PR DESCRIPTION
Fixes #437. Essentially if you'll accept null you're too accepting (un-typed params, variadics etc.) I also added a test to check handling interfaces still works.