### PR TITLE
Address Typos and Make Grammatical Improvements in Documentation

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -10,7 +10,7 @@ If you've never worked with event sourcing, or are uncertain about what projecto
 Event sourcing might be a good choice for your project if:
 
 - your app needs to make decisions based on the past
-- your app has auditing requirements: the reason why your app is in a certain state is equally as important as the state itself
+- your app has auditing requirements: the reason why your app is in a certain state is equally important as the state itself
 - you foresee that there will be a reporting need in the future, but you don't know yet which data you need to collect for those reports
 
 Some concepts in the package, for example the testing methods of aggregates, were inspired by [Frank De Jonge](https://twitter.com/frankdejonge/)'s [EventSauce](https://eventsauce.io/) package.

--- a/docs/using-aggregates/creating-and-configuring-aggregates.md
+++ b/docs/using-aggregates/creating-and-configuring-aggregates.md
@@ -40,7 +40,7 @@ $myAggregate = new MyAggregate();
 $myAggregate->loadUuid($uuid);
 ```
 
-The `load` method is handy when injecting aggretate roots in constructors or classes where method injection is supported.
+The `load` method is handy when injecting aggregate roots in constructors or classes where method injection is supported.
 
 ```php
 public function handle(MyAggregate $aggregate) {
@@ -100,7 +100,7 @@ MyAggregate::retrieve($uuid) // will cause all events for this uuid to be fed to
 
 Persisting an aggregate root will write all newly recorded events to the database. The newly persisted events will get passed to all projectors and reactors.
 
-By default, the event won't be fired on Laravels event bus. To dispatch events when they are stored, you can set the `dispatch_events_from_aggregate_roots` value in the `event-sourcing` config file to `true`. 
+By default, the event won't be fired on Laravel's event bus. To dispatch events when they are stored, you can set the `dispatch_events_from_aggregate_roots` value in the `event-sourcing` config file to `true`. 
 
 ## Want to know more?
 

--- a/docs/using-projectors/making-sure-events-get-handled-in-the-right-order.md
+++ b/docs/using-projectors/making-sure-events-get-handled-in-the-right-order.md
@@ -32,7 +32,7 @@ class MyProjector extends Projector
 }
 ```
 
-Note that providing a weight on a queued projector won't guarentee execution order.
+Note that providing a weight on a queued projector won't guarantee execution order.
 
 ## Want to know more?
 

--- a/docs/using-projectors/writing-your-first-projector.md
+++ b/docs/using-projectors/writing-your-first-projector.md
@@ -376,7 +376,7 @@ Projections are very fast to query. Imagine that our application has processed m
 
 ## Using Factories in Tests
 
-In the example above the `Account` model contains the necessary logic to create an `Account`, this pattern may require you to revise how you create test data using model factories. One possible solution is illustated below.
+In the example above the `Account` model contains the necessary logic to create an `Account`, this pattern may require you to revise how you create test data using model factories. One possible solution is illustrated below.
 
 ```php
 public function test_can_have_many_accounts()

--- a/docs/using-reactors/creating-and-configuring-reactors.md
+++ b/docs/using-reactors/creating-and-configuring-reactors.md
@@ -196,7 +196,7 @@ class MyReactor
 }
 ```
 
-Note that providing a weight on a queued reactor won't guarentee execution order.
+Note that providing a weight on a queued reactor won't guarantee execution order.
 
 ## Want to know more?
 


### PR DESCRIPTION
Address various typos and make grammatical improvements in the documentation to enhance its accuracy.