### PR TITLE
Fix Some Typos in Method Names, Namespaces, and PHPDoc Annotations

### DIFF
--- a/src/Exceptions/InvalidEventHandler.php
+++ b/src/Exceptions/InvalidEventHandler.php
@@ -22,7 +22,7 @@ class InvalidEventHandler extends Exception
 
     public static function notAProjector(object $object): self
     {
-        return new static('`'.get_class($object).'` must implement Spatie\EventProcjetor\Projectors\Projector');
+        return new static('`'.get_class($object).'` must implement Spatie\EventProjector\Projectors\Projector');
     }
 
     public static function notAnEventHandler(object $object): self

--- a/tests/AggregateRoots/CommandHandlerTest.php
+++ b/tests/AggregateRoots/CommandHandlerTest.php
@@ -102,7 +102,7 @@ it('should dispatch command to aggregate', function () {
 
     assertCount(1, CartForCommand::retrieve($this->UUID)->cartItems->items);
 
-    // Assert that commands are dispatched to the AR iteself
+    // Assert that commands are dispatched to the AR itself
     $bus->dispatch(new ClearCart(
         $this->UUID,
     ));

--- a/tests/TestClasses/Projectors/ProjectorWithoutHandlesEvents.php
+++ b/tests/TestClasses/Projectors/ProjectorWithoutHandlesEvents.php
@@ -14,7 +14,7 @@ class ProjectorWithoutHandlesEvents extends Projector
         $event->account->addMoney($event->amount);
     }
 
-    public function anotherFunctionThatHandlesMoneySubstracted(MoneySubtractedEvent $event)
+    public function anotherFunctionThatHandlesMoneySubtracted(MoneySubtractedEvent $event)
     {
         $event->account->subtractMoney($event->amount);
     }
@@ -23,7 +23,7 @@ class ProjectorWithoutHandlesEvents extends Projector
     {
     }
 
-    public function functionWithUnreleatedClassTypeHint(Collection $test)
+    public function functionWithUnrelatedClassTypeHint(Collection $test)
     {
     }
 


### PR DESCRIPTION
I've corrected some typos across method names, namespaces, and PHPDoc annotations.