### PR TITLE
Change the column type of snapshots.aggregate_version

### DIFF
--- a/database/migrations/create_snapshots_table.php.stub
+++ b/database/migrations/create_snapshots_table.php.stub
@@ -11,7 +11,7 @@ return new class extends Migration
         Schema::create('snapshots', function (Blueprint $table) {
             $table->id();
             $table->uuid('aggregate_uuid');
-            $table->unsignedInteger('aggregate_version');
+            $table->unsignedBigInteger('aggregate_version');
             $table->jsonb('state');
 
             $table->timestamps();


### PR DESCRIPTION
Just started using this package for the first time for a new project. 
Noticed the two migrations that are included have a different column type for what appears to be the same data. (As the snapshot's aggregate_version always seems to match the corresponding event's aggregate_version).
I decided to use the bigger data type of the two as this seemed like the safer option. 