### PR TITLE
L11 compatibility

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -1,52 +1,59 @@
 name: run-tests
 
 on:
-    push:
-    pull_request:
-    schedule:
-        - cron: '0 0 * * *'
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
-    test:
-        runs-on: ubuntu-latest
-        strategy:
-            matrix:
-                php: [8.2, 8.1, 8.0]
-                laravel: [9.*, 10.*]
-                dependency-version: [prefer-lowest, prefer-stable]
-                include:
-                    - laravel: 10.*
-                      testbench: 8.*
-                    - laravel: 9.*
-                      testbench: 7.*
-                exclude:
-                    - laravel: 10.*
-                      php: 8.0
+  test:
+    runs-on: ubuntu-latest
 
-        name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
+    strategy:
+      matrix:
+        php: [8.2, 8.1, 8.0]
+        laravel: ['9.*', '10.*', '11.*']
+        dependency-version: [prefer-lowest, prefer-stable]
+        include:
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 9.*
+            testbench: 7.*
+          - laravel: 11.*
+            testbench: 9.*
+        exclude:
+          - laravel: 10.*
+            php: 8.0
+          - laravel: 11.*
+            php: 8.1
+          - laravel: 11.*
+            php: 8.0
 
-        steps:
-            - name: Checkout code
-              uses: actions/checkout@v4
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 
-            - name: Setup PHP
-              uses: shivammathur/setup-php@v2
-              with:
-                  php-version: ${{ matrix.php }}
-                  extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick
-                  coverage: none
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
 
-            - name: Create database
-              run: |
-                sudo /etc/init.d/mysql start
-                mysql  -u root -proot -e 'CREATE DATABASE IF NOT EXISTS laravel_event_sourcing;'
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, mysql, mysqli, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
 
-            - name: Install dependencies
-              run: |
-                  composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-                  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+      - name: Create database
+        run: |
+          sudo /etc/init.d/mysql start
+          mysql  -u root -proot -e 'CREATE DATABASE IF NOT EXISTS laravel_event_sourcing;'
 
-            - name: Execute tests
-              run: vendor/bin/pest
-              env:
-                  DB_PASSWORD: root
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "nesbot/carbon:^2.63" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction --no-suggest
+
+      - name: Execute tests
+        run: vendor/bin/pest
+        env:
+          DB_PASSWORD: root

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ coverage
 .phpunit.result.cache
 .php_cs.cache
 .php-cs-fixer.cache
+.phpunit.cache

--- a/composer.json
+++ b/composer.json
@@ -23,28 +23,28 @@
     "require": {
         "php": "^8.0",
         "ext-json": "*",
-        "illuminate/console": "^9.0|^10.0",
-        "illuminate/database": "^9.0|^10.0",
-        "illuminate/events": "^9.0|^10.0",
-        "illuminate/support": "^9.0|^10.0",
+        "illuminate/console": "^9.0|^10.0|^11.0",
+        "illuminate/database": "^9.0|^10.0|^11.0",
+        "illuminate/events": "^9.0|^10.0|^11.0",
+        "illuminate/support": "^9.0|^10.0|^11.0",
         "phpdocumentor/reflection-docblock": "^5.2",
         "spatie/better-types": "^0.1.2",
         "spatie/laravel-package-tools": "^1.9",
         "spatie/laravel-schemaless-attributes": "^2.0",
-        "symfony/finder": "^6.0",
-        "symfony/property-access": "^6.0",
-        "symfony/property-info": "^6.0",
-        "symfony/serializer": "^6.0"
+        "symfony/finder": "^6.0|^7.0",
+        "symfony/property-access": "^6.0|^7.0",
+        "symfony/property-info": "^6.0|^7.0",
+        "symfony/serializer": "^6.0|^7.0"
     },
     "require-dev": {
         "laravel/horizon": "^5.7",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^7.0|^8.0",
-        "pestphp/pest": "^1.22",
-        "phpunit/phpunit": "^9.5.10",
+        "orchestra/testbench": "^7.0|^8.0|^9.0",
+        "pestphp/pest": "^1.22|^2.34",
+        "phpunit/phpunit": "^9.5.10|^10.5",
         "spatie/fork": "^1.0",
-        "spatie/pest-plugin-snapshots": "^1.1",
-        "spatie/phpunit-snapshot-assertions": "^4.0"
+        "spatie/pest-plugin-snapshots": "^1.1|^2.1",
+        "spatie/phpunit-snapshot-assertions": "^4.0|^5.1"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "illuminate/events": "^9.0|^10.0|^11.0",
         "illuminate/support": "^9.0|^10.0|^11.0",
         "phpdocumentor/reflection-docblock": "^5.2",
-        "spatie/better-types": "^0.1.2",
+        "spatie/better-types": "^0.2.0",
         "spatie/laravel-package-tools": "^1.9",
         "spatie/laravel-schemaless-attributes": "^2.0",
         "symfony/finder": "^6.0|^7.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,10 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" backupStaticAttributes="false" colors="true" verbose="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
-  <coverage>
-    <include>
-      <directory suffix=".php">src/</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" backupGlobals="false" colors="true" processIsolation="false" stopOnFailure="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
   <testsuites>
     <testsuite name="Spatie Test Suite">
       <directory>tests</directory>
@@ -18,4 +13,9 @@
     <env name="DB_HOST" value="127.0.0.1"/>
     <env name="DB_PORT" value="3306"/>
   </php>
+  <source>
+    <include>
+      <directory suffix=".php">src/</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Support/CarbonNormalizer.php
+++ b/src/Support/CarbonNormalizer.php
@@ -25,7 +25,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritdoc
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return $data instanceof CarbonInterface;
     }
@@ -41,7 +41,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritDoc
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return is_a($type, CarbonInterface::class, true);
     }

--- a/src/Support/ModelIdentifierNormalizer.php
+++ b/src/Support/ModelIdentifierNormalizer.php
@@ -31,7 +31,7 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function supportsNormalization(mixed $data, string $format = null): bool
+    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
     {
         return ($data instanceof QueueableEntity || $data instanceof QueueableCollection);
     }
@@ -51,7 +51,7 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null): bool
+    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
     {
         return $this->normalizedDataIsModelIdentifier($data)
             && $this->isNormalizedToModelIdentifier($type);

--- a/src/Support/ObjectNormalizer.php
+++ b/src/Support/ObjectNormalizer.php
@@ -15,8 +15,6 @@ class ObjectNormalizer extends SymfonyAbstractObjectNormalizer
 {
     protected SymfonyObjectNormalizer $normalizer;
 
-    protected PropertyAccessorInterface $propertyAccessor;
-
     public function __construct(?ClassMetadataFactoryInterface $classMetadataFactory = null, ?NameConverterInterface $nameConverter = null, ?PropertyAccessorInterface $propertyAccessor = null, ?PropertyTypeExtractorInterface $propertyTypeExtractor = null, ?ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, ?callable $objectClassResolver = null, array $defaultContext = [])
     {
 

--- a/src/Support/ObjectNormalizer.php
+++ b/src/Support/ObjectNormalizer.php
@@ -20,11 +20,13 @@ class ObjectNormalizer extends SymfonyAbstractObjectNormalizer
     public function __construct(?ClassMetadataFactoryInterface $classMetadataFactory = null, ?NameConverterInterface $nameConverter = null, ?PropertyAccessorInterface $propertyAccessor = null, ?PropertyTypeExtractorInterface $propertyTypeExtractor = null, ?ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, ?callable $objectClassResolver = null, array $defaultContext = [])
     {
 
+        $propertyTypeExtractor = $propertyTypeExtractor ?? new PhpDocExtractor();
+
         $this->normalizer = new SymfonyObjectNormalizer(
             $classMetadataFactory,
             $nameConverter,
             $propertyAccessor,
-            $propertyTypeExtractor ?? new PhpDocExtractor(),
+            $propertyTypeExtractor,
             $classDiscriminatorResolver,
             $objectClassResolver,
             $defaultContext
@@ -33,7 +35,7 @@ class ObjectNormalizer extends SymfonyAbstractObjectNormalizer
         parent::__construct(
             $classMetadataFactory,
             $nameConverter,
-            $propertyTypeExtractor ?? new PhpDocExtractor(),
+            $propertyTypeExtractor,
             $classDiscriminatorResolver,
             $objectClassResolver,
             $defaultContext

--- a/src/Support/ObjectNormalizer.php
+++ b/src/Support/ObjectNormalizer.php
@@ -8,19 +8,34 @@ use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
+use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer as SymfonyAbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer as SymfonyObjectNormalizer;
 
-class ObjectNormalizer extends SymfonyObjectNormalizer
+class ObjectNormalizer extends SymfonyAbstractObjectNormalizer
 {
-    public function __construct(ClassMetadataFactoryInterface $classMetadataFactory = null, NameConverterInterface $nameConverter = null, PropertyAccessorInterface $propertyAccessor = null, PropertyTypeExtractorInterface $propertyTypeExtractor = null, ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, callable $objectClassResolver = null, array $defaultContext = [])
+    protected SymfonyObjectNormalizer $normalizer;
+
+    protected PropertyAccessorInterface $propertyAccessor;
+
+    public function __construct(?ClassMetadataFactoryInterface $classMetadataFactory = null, ?NameConverterInterface $nameConverter = null, ?PropertyAccessorInterface $propertyAccessor = null, ?PropertyTypeExtractorInterface $propertyTypeExtractor = null, ?ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, ?callable $objectClassResolver = null, array $defaultContext = [])
     {
-        parent::__construct(
+
+        $this->normalizer = new SymfonyObjectNormalizer(
             $classMetadataFactory,
-            $nameConverter,
-            $propertyAccessor,
-            $propertyTypeExtractor ?? new PhpDocExtractor(),
-            $classDiscriminatorResolver,
-            $objectClassResolver,
+            $nameConverter, 
+            $propertyAccessor, 
+            $propertyTypeExtractor ?? new PhpDocExtractor(), 
+            $classDiscriminatorResolver, 
+            $objectClassResolver, 
+            $defaultContext
+        );
+
+        parent::__construct(
+            $classMetadataFactory, 
+            $nameConverter, 
+            $propertyTypeExtractor ?? new PhpDocExtractor(), 
+            $classDiscriminatorResolver, 
+            $objectClassResolver, 
             $defaultContext
         );
     }
@@ -28,5 +43,25 @@ class ObjectNormalizer extends SymfonyObjectNormalizer
     public function getSupportedTypes(?string $format): array
     {
         return ['object' => false];
+    }
+
+    protected function extractAttributes(object $object, ?string $format = null, array $context = []): array
+    {
+        return $this->normalizer->extractAttributes($object, $format, $context);
+    }
+
+    protected function getAttributeValue(object $object, string $attribute, ?string $format = null, array $context = []): mixed
+    {
+        return $this->normalizer->getAttributeValue($object, $attribute, $format, $context);
+    }
+
+    protected function setAttributeValue(object $object, string $attribute, mixed $value, ?string $format = null, array $context = []): void
+    {
+        $this->normalizer->setAttributeValue($object, $attribute, $value, $format, $context);
+    }
+
+    protected function getAllowedAttributes(string|object $classOrObject, array $context, bool $attributesAsString = false): array|bool
+    {
+        return $this->normalizer->getAllowedAttributes($classOrObject, $context, $attributesAsString);
     }
 }


### PR DESCRIPTION
[symfony/serializer](https://github.com/symfony/serializer) made the `Symfony\Component\Serializer\Normalizer\ObjectNormalizer` class final and now requires to implement some of the core methods. 

We still only needed to change `getSupportedTypes()` so rather than copy in whole function bodies I just grabbed an instance of their `ObjectNormalizer` and used it for the rest.