### PR TITLE
AllowDynamicProperties to suppress PHP warnings on 8.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "spatie/laravel-package-tools": "^1.9",
         "spatie/laravel-schemaless-attributes": "^2.0",
         "symfony/finder": "^6.0|^7.0",
+        "symfony/polyfill-php82": "^1.29",
         "symfony/property-access": "^6.0|^7.0",
         "symfony/property-info": "^6.0|^7.0",
         "symfony/serializer": "^6.0|^7.0"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "spatie/laravel-package-tools": "^1.9",
         "spatie/laravel-schemaless-attributes": "^2.0",
         "symfony/finder": "^6.0|^7.0",
-        "symfony/polyfill-php82": "^1.29",
+        "symfony/polyfill-php82": "*",
         "symfony/property-access": "^6.0|^7.0",
         "symfony/property-info": "^6.0|^7.0",
         "symfony/serializer": "^6.0|^7.0"

--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\EventSourcing\StoredEvents;
 
+use AllowDynamicProperties;
 use Exception;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Support\Arr;
@@ -12,6 +13,7 @@ use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\Facades\Projectionist;
 use Spatie\EventSourcing\StoredEvents\Exceptions\InvalidStoredEvent;
 
+#[AllowDynamicProperties]
 class StoredEvent implements Arrayable
 {
     public ?int $id;


### PR DESCRIPTION
Fixes #435 