### PR TITLE
Add config to enforce every event has an alias.

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -83,6 +83,13 @@ return [
     'stored_event_job' => Spatie\EventSourcing\StoredEvents\HandleStoredEventJob::class,
 
     /*
+     * Similar to Relation::enforceMorphMap() this option will make sure that every event has a
+     * corresponding alias defined. Otherwise, an exception is thrown
+     * if you try to persist an event without alias.
+     */
+    'enforce_event_class_map' => false,
+
+    /*
      * Similar to Relation::morphMap() you can define which alias responds to which
      * event class. This allows you to change the namespace or class names
      * of your events but still handle older events correctly.

--- a/docs/advanced-usage/using-aliases-for-stored-event-classes.md
+++ b/docs/advanced-usage/using-aliases-for-stored-event-classes.md
@@ -19,3 +19,14 @@ To get around this you can define event class aliases in the `event-sourcing.php
 ```
 
 With this configuration, instead of saving `\App\Events\MoneyAddedEvent` in the database, it just stores `money_added` so you can change the event's classname and namespace. Just make sure to also change the mapping!
+
+If you want to make sure every event has an alias assigned you can enable the `enforce_event_class_map` option in the config: 
+
+```php
+    /*
+     * Similar to Relation::enforceMorphMap() this option will make sure that every event has a
+     * corresponding alias defined. Otherwise, an exception is thrown
+     * if you try to persist an event without alias.
+     */
+    'enforce_event_class_map' => true,
+```

--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -81,6 +81,13 @@ use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSo
     'stored_event_job' => HandleStoredEventJob::class,
 
     /*
+     * Similar to Relation::enforceMorphMap() this option will make sure that every event has a
+     * corresponding alias defined. Otherwise, an exception is thrown
+     * if you try to persist an event without alias.
+     */
+    'enforce_event_class_map' => false,
+
+    /*
      * Similar to Relation::morphMap() you can define which alias responds to which
      * event class. This allows you to change the namespace or class names
      * of your events but still handle older events correctly.

--- a/src/StoredEvents/Exceptions/EventClassMapMissing.php
+++ b/src/StoredEvents/Exceptions/EventClassMapMissing.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Spatie\EventSourcing\StoredEvents\Exceptions;
+
+use Exception;
+use Spatie\EventSourcing\StoredEvents\StoredEvent;
+
+class EventClassMapMissing extends Exception
+{
+    public static function noEventClassMappingProvided(string $eventClass): self
+    {
+        return new static(
+            "The alias for $eventClass is missing. Add it to the event_class_map config or disable the enforce_event_class_map option.",
+        );
+    }
+}

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -22,7 +22,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
     {
         $this->storedEventModel = (string) config('event-sourcing.stored_event_model', EloquentStoredEvent::class);
 
-        if (!new $this->storedEventModel() instanceof EloquentStoredEvent) {
+        if (! new $this->storedEventModel() instanceof EloquentStoredEvent) {
             throw new InvalidEloquentStoredEventModel("The class {$this->storedEventModel} must extend EloquentStoredEvent");
         }
     }
@@ -42,8 +42,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
             $query->whereAggregateRoot($uuid);
         }
 
-        return $query->orderBy('id')->cursor()->map(fn(EloquentStoredEvent $storedEvent
-        ) => $storedEvent->toStoredEvent());
+        return $query->orderBy('id')->cursor()->map(fn(EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }
 
     public function retrieveAllStartingFrom(int $startingFrom, string $uuid = null): LazyCollection
@@ -72,7 +71,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         return $query
             ->orderBy('id')
             ->cursor()
-            ->map(fn(EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
+            ->map(fn (EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }
 
     public function persist(ShouldBeStored $event, string $uuid = null): StoredEvent
@@ -91,8 +90,8 @@ class EloquentStoredEventRepository implements StoredEventRepository
             'event_version' => $event->eventVersion(),
             'event_class' => $this->getEventClass(get_class($event)),
             'meta_data' => json_encode($event->metaData() + [
-                    MetaData::CREATED_AT => $createdAt->toDateTimeString(),
-                ]),
+                MetaData::CREATED_AT => $createdAt->toDateTimeString(),
+            ]),
             'created_at' => $createdAt,
         ]);
 
@@ -134,7 +133,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         $map = config('event-sourcing.event_class_map', []);
         $isMappingEnforced = config('event-sourcing.enforce_event_class_map', false);
 
-        if (!empty($map) && in_array($class, $map)) {
+        if (! empty($map) && in_array($class, $map)) {
             return array_search($class, $map, true);
         }
 
@@ -148,8 +147,8 @@ class EloquentStoredEventRepository implements StoredEventRepository
     public function getLatestAggregateVersion(string $aggregateUuid): int
     {
         return $this->getQuery()
-            ->whereAggregateRoot($aggregateUuid)
-            ->max('aggregate_version') ?? 0;
+                ->whereAggregateRoot($aggregateUuid)
+                ->max('aggregate_version') ?? 0;
     }
 
     private function prepareEventModelQuery(int $startingFrom, string $uuid = null): Builder

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -42,7 +42,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
             $query->whereAggregateRoot($uuid);
         }
 
-        return $query->orderBy('id')->cursor()->map(fn(EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
+        return $query->orderBy('id')->cursor()->map(fn (EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }
 
     public function retrieveAllStartingFrom(int $startingFrom, string $uuid = null): LazyCollection
@@ -54,7 +54,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
             ->orderBy('id')
             ->lazyById();
 
-        return $lazyCollection->map(fn(EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
+        return $lazyCollection->map(fn (EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }
 
     public function countAllStartingFrom(int $startingFrom, string $uuid = null): int

--- a/tests/Models/StoredEventTest.php
+++ b/tests/Models/StoredEventTest.php
@@ -5,6 +5,7 @@ namespace Spatie\EventSourcing\Tests\Models;
 use Carbon\Carbon;
 use Illuminate\Support\Str;
 
+use Spatie\EventSourcing\StoredEvents\Exceptions\EventClassMapMissing;
 use function PHPUnit\Framework\assertArrayHasKey;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertEqualsCanonicalizing;
@@ -62,6 +63,13 @@ it('will store the alias when a classname is found in the event class map', func
     assertEquals(MoneyAddedEvent::class, EloquentStoredEvent::first()->toStoredEvent()->event_class);
     $this->assertDatabaseHas('stored_events', ['event_class' => 'money_added']);
 });
+
+it('will throw exception if event class map is enforced and no mapping is provided', function () {
+    $this->setConfig('event-sourcing.enforce_event_class_map', true);
+    $this->setConfig('event-sourcing.event_class_map', []);
+
+    fireEvents();
+})->throws(EventClassMapMissing::class);
 
 it('allows to modify metadata with offset set in eloquent model', function () {
     EloquentStoredEvent::creating(function (EloquentStoredEvent $event) {


### PR DESCRIPTION
Like with `Relation::enforceMorphMap` i added a config option to always throw an exception if an event without alias is persisted. 


Thank you for the great package if you have questions or change requests I am happy to update the PR. 