### PR TITLE
Use custom serializer while persisting events

### DIFF
--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -93,10 +93,9 @@ class EloquentStoredEventRepository implements StoredEventRepository
             throw new InvalidStoredEvent();
         }
 
+        $serializerClass = EventSerializer::class;
         if ($serializerAttribute = $reflectionClass->getAttributes(EventSerializerAttribute::class)[0] ?? null) {
-            $serializerClass = ($serializerAttribute->newInstance())->serializerClass;
-        } else {
-            $serializerClass = EventSerializer::class;
+            $serializerClass = $serializerAttribute->newInstance()->serializerClass;
         }
 
         $eloquentStoredEvent->setRawAttributes([

--- a/tests/EloquentStoredEventRepositoryTest.php
+++ b/tests/EloquentStoredEventRepositoryTest.php
@@ -8,6 +8,7 @@ use function PHPUnit\Framework\assertSame;
 use Spatie\EventSourcing\StoredEvents\Repositories\EloquentStoredEventRepository;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\AccountAggregateRoot;
 use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithCustomSerializer;
 
 it('can get the latest version id for a given aggregate uuid', function () {
     $eloquentStoredEventRepository = new EloquentStoredEventRepository();
@@ -36,4 +37,14 @@ it('sets the original event on persist', function () {
     $storedEvent = $eloquentStoredEventRepository->persist($originalEvent, 'uuid-1', 1);
 
     assertSame($originalEvent, $storedEvent->event);
+});
+
+it('uses the custom serializer if one is set', function () {
+    $eloquentStoredEventRepository = app(EloquentStoredEventRepository::class);
+
+    $originalEvent = new EventWithCustomSerializer('default message');
+    $storedEvent = $eloquentStoredEventRepository->persist($originalEvent, 'uuid-1', 1);
+
+    $eventFromDatabase = $eloquentStoredEventRepository->find($storedEvent->id)->event;
+    assertSame('message set by custom serializer', $eventFromDatabase->message);
 });

--- a/tests/TestClasses/EventSerializer/DummySerializer.php
+++ b/tests/TestClasses/EventSerializer/DummySerializer.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\EventSerializer;
+
+use DateTimeZone;
+use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class DummySerializer extends JsonEventSerializer
+{
+    public function serialize(ShouldBeStored $event): string
+    {
+        return '{"message":"message set by custom serializer"}';
+    }
+}

--- a/tests/TestClasses/Events/EventWithCustomSerializer.php
+++ b/tests/TestClasses/Events/EventWithCustomSerializer.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Events;
+
+use Spatie\EventSourcing\Attributes\EventSerializer;
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+use Spatie\EventSourcing\Tests\TestClasses\EventSerializer\DummySerializer;
+
+#[EventSerializer(DummySerializer::class)]
+class EventWithCustomSerializer extends ShouldBeStored
+{
+    public string $message;
+
+    public function __construct(string $message)
+    {
+        $this->message = $message;
+    }
+}


### PR DESCRIPTION
I stumbled upon issue #414 while setting up custom event serializers.

This PR fixes this issue by also using the custom event serializer while persisting events.

If you have any questions, please reach out to me!

## Note About Versioning
I don't know if the previous behavior was a bug or intentional, but "fixing" it changes how events are serialized into the database. Therefore, it probably makes sense to release this in a major version update.

