### PR TITLE
Add reflection exception error message to InvalidStoredEvent exception

### DIFF
--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -118,7 +118,7 @@ class StoredEvent implements Arrayable
         try {
             $reflectionClass = new ReflectionClass($this->event_class);
         } catch (ReflectionException $exception) {
-            throw new InvalidStoredEvent();
+            throw new InvalidStoredEvent($exception->getMessage());
         }
 
         if ($serializerAttribute = $reflectionClass->getAttributes(EventSerializerAttribute::class)[0] ?? null) {


### PR DESCRIPTION
Adding this message makes debugging easier during event replay.

-- 
Before

```
Replaying 44037 events...
 37995/44037 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░]  86%
   Spatie\EventSourcing\StoredEvents\Exceptions\InvalidStoredEvent 

  

  at vendor/spatie/laravel-event-sourcing/src/StoredEvents/StoredEvent.php:121
    117▕ 
    118▕         try {
    119▕             $reflectionClass = new ReflectionClass($this->event_class);
    120▕         } catch (ReflectionException $exception) {
  ➜ 121▕             throw new InvalidStoredEvent();
    122▕         }
    123▕ 
    124▕         if ($serializerAttribute = $reflectionClass->getAttributes(EventSerializerAttribute::class)[0] ?? null) {
    125▕             $serializerClass = ($serializerAttribute->newInstance())->serializerClass;

      +20 vendor frames 

  21  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

After:
```
37995/44037 [▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓░░░░]  86%
   Spatie\EventSourcing\StoredEvents\Exceptions\InvalidStoredEvent 

  Class "App\Domains\ViewSync\StorableEvents\ViewSyncChangeCreated" does not exist

  at vendor/spatie/laravel-event-sourcing/src/StoredEvents/StoredEvent.php:121
    117▕ 
    118▕         try {
    119▕             $reflectionClass = new ReflectionClass($this->event_class);
    120▕         } catch (ReflectionException $exception) {
  ➜ 121▕             throw new InvalidStoredEvent($exception->getMessage());
    122▕         }
    123▕ 
    124▕         if ($serializerAttribute = $reflectionClass->getAttributes(EventSerializerAttribute::class)[0] ?? null) {
    125▕             $serializerClass = ($serializerAttribute->newInstance())->serializerClass;

      +20 vendor frames 

  21  artisan:35
      Illuminate\Foundation\Console\Kernel::handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
```

Thanks
