### PR TITLE
add failing test for serializing `created_at` event property

### DIFF
--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -8,6 +8,7 @@ use DateTimeImmutable;
 
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertInstanceOf;
+use function PHPUnit\Framework\assertStringContainsString;
 
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithArray;
@@ -15,6 +16,7 @@ use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithCarbon;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithDatetime;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithDocblock;
 use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithoutSerializedModels;
+use Spatie\EventSourcing\Tests\TestClasses\Events\EventWithCreatedAtProperty;
 use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEvent;
 use Spatie\EventSourcing\Tests\TestClasses\EventSerializer\UpgradeSerializer;
 use Spatie\EventSourcing\Tests\TestClasses\Models\Account;
@@ -72,6 +74,18 @@ it('can deserialize an event with datetime', function () {
     $normalizedEvent = $this->eventSerializer->deserialize(get_class($event), $json, 1);
 
     assertInstanceOf(DateTimeImmutable::class, $normalizedEvent->value);
+});
+
+it('does not modify `created_at` event properties', function() {
+    $event = new EventWithCreatedAtProperty('2020-01-01 00:00:00');
+
+    $json = $this->eventSerializer->serialize($event);
+
+    assertEquals('{"created_at":"2020-01-01 00:00:00"}', $json);
+
+    $normalizedEvent = $this->eventSerializer->deserialize(get_class($event), $json, 1);
+
+    assertEquals('2020-01-01 00:00:00', $normalizedEvent->created_at);
 });
 
 it('can deserialize an event with carbon', function () {

--- a/tests/TestClasses/Events/EventWithCreatedAtProperty.php
+++ b/tests/TestClasses/Events/EventWithCreatedAtProperty.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests\TestClasses\Events;
+
+use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
+
+class EventWithCreatedAtProperty extends ShouldBeStored
+{
+    public string $created_at;
+
+    public function __construct(string $created_at)
+    {
+        $this->created_at = $created_at;
+    }
+}


### PR DESCRIPTION
Hi there!

I encountered this bug when I was trying to store a collection of Eloquent models as events (Long story...)

If you define a stored event property with the name `created_at`, it will be set to null when the event is serialiazed.

I've been digging through the code, trying to figure out why this happens and found the following:

The ObjectNormalizer uses the PropertyAccessor from Symfony, and setting the following line (**In the Symfony package**) to false will fix the behavior:
https://github.com/symfony/property-access/blob/7.1/PropertyAccessor.php#L472

The ObjectNormalizer is triggering the PropertyAccessor on this line:
https://github.com/spatie/laravel-event-sourcing/blob/main/src/Support/ObjectNormalizer.php#L55

Do you know if there is a way to configure this from outside? I'm open to contributing a fix myself, but I'm a little out of my comfort zone, and I don't want to reinvent any wheels unnecessarily 😄 