### PR TITLE
Update installation-setup.md to match actual contents of config/event-sourcing.php

### DIFF
--- a/docs/installation-setup.md
+++ b/docs/installation-setup.md
@@ -25,19 +25,27 @@ php artisan vendor:publish --provider="Spatie\EventSourcing\EventSourcingService
 This is the default content of the config file that will be published at `config/event-sourcing.php`:
 
 ```php
-use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSourcing\Models\EloquentStoredEvent;use Spatie\EventSourcing\StoredEvents\HandleStoredEventJob;return [
+<?php
+
+return [
 
     /*
      * These directories will be scanned for projectors and reactors. They
-     * will be automatically registered to projectionist automatically.
+     * will be registered to Projectionist automatically.
      */
     'auto_discover_projectors_and_reactors' => [
-        app_path(),
+        app()->path(),
     ],
 
     /*
+     * This directory will be used as the base path when scanning
+     * for projectors and reactors.
+     */
+    'auto_discover_base_path' => base_path(),
+
+    /*
      * Projectors are classes that build up projections. You can create them by performing
-     * `php artisan make:projector`.  When not using auto-discovery
+     * `php artisan event-sourcing:create-projector`. When not using auto-discovery,
      * Projectors can be registered in this array or a service provider.
      */
     'projectors' => [
@@ -45,8 +53,8 @@ use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSo
     ],
 
     /*
-     * Reactors are classes that handle side effects. You can create them by performing
-     * `php artisan make:reactor`. When not using auto-discovery
+     * Reactors are classes that handle side-effects. You can create them by performing
+     * `php artisan event-sourcing:create-reactor`. When not using auto-discovery
      * Reactors can be registered in this array or a service provider.
      */
     'reactors' => [
@@ -60,25 +68,46 @@ use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSo
     'queue' => env('EVENT_PROJECTOR_QUEUE_NAME', null),
 
     /*
-     * When a projector or reactor throws an exception the event projectionist can catch it
+     * When a Projector or Reactor throws an exception the event Projectionist can catch it
      * so all other projectors and reactors can still do their work. The exception will
-     * be passed to the `handleException` method on that projector or reactor.
+     * be passed to the `handleException` method on that Projector or Reactor.
      */
     'catch_exceptions' => env('EVENT_PROJECTOR_CATCH_EXCEPTIONS', false),
 
     /*
-     * This class is responsible for storing events. To add extra behaviour you
-     * can change this to a class of your own. The only restriction is that
-     * it should extend \Spatie\EventSourcing\Models\EloquentStoredEvent.
+     * This class is responsible for storing events in the EloquentStoredEventRepository.
+     * To add extra behaviour you can change this to a class of your own. It should
+     * extend the \Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent model.
      */
-    'stored_event_model' => EloquentStoredEvent::class,
+    'stored_event_model' => Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent::class,
 
     /*
-     * This class is responsible for handle stored events. To add extra behaviour you
+     * This class is responsible for storing events. To add extra behaviour you
      * can change this to a class of your own. The only restriction is that
-     * it should implement \Spatie\EventSourcing\HandleDomainEventJob.
+     * it should implement \Spatie\EventSourcing\StoredEvents\Repositories\EloquentStoredEventRepository.
      */
-    'stored_event_job' => HandleStoredEventJob::class,
+    'stored_event_repository' => Spatie\EventSourcing\StoredEvents\Repositories\EloquentStoredEventRepository::class,
+
+    /*
+     * This class is responsible for storing snapshots. To add extra behaviour you
+     * can change this to a class of your own. The only restriction is that
+     * it should implement \Spatie\EventSourcing\Snapshots\EloquentSnapshotRepository.
+     */
+    'snapshot_repository' => Spatie\EventSourcing\Snapshots\EloquentSnapshotRepository::class,
+
+    /*
+     * This class is responsible for storing events in the EloquentSnapshotRepository.
+     * To add extra behaviour you can change this to a class of your own. It should
+     * extend the \Spatie\EventSourcing\Snapshots\EloquentSnapshot model.
+     */
+    'snapshot_model' => Spatie\EventSourcing\Snapshots\EloquentSnapshot::class,
+
+    /*
+     * This class is responsible for handling stored events. To add extra behaviour you
+     * can change this to a class of your own. The only restriction is that
+     * it should implement \Spatie\EventSourcing\StoredEvents\HandleDomainEventJob.
+     */
+    'stored_event_job' => Spatie\EventSourcing\StoredEvents\HandleStoredEventJob::class,
 
     /*
      * Similar to Relation::enforceMorphMap() this option will make sure that every event has a
@@ -99,16 +128,38 @@ use Spatie\EventSourcing\EventSerializers\JsonEventSerializer;use Spatie\EventSo
      * and stored as json. You can customize the class name. A valid serializer
      * should implement Spatie\EventSourcing\EventSerializers\EventSerializer.
      */
-    'event_serializer' => JsonEventSerializer::class,
+    'event_serializer' => Spatie\EventSourcing\EventSerializers\JsonEventSerializer::class,
 
     /*
-     * In production, you likely don't want the package to auto discover the event handlers
+     * These classes normalize and restore your events when they're serialized. They allow
+     * you to efficiently store PHP objects like Carbon instances, Eloquent models, and
+     * Collections. If you need to store other complex data, you can add your own normalizers
+     * to the chain. See https://symfony.com/doc/current/components/serializer.html#normalizers
+     */
+    'event_normalizers' => [
+        Spatie\EventSourcing\Support\CarbonNormalizer::class,
+        Spatie\EventSourcing\Support\ModelIdentifierNormalizer::class,
+        Symfony\Component\Serializer\Normalizer\DateTimeNormalizer::class,
+        Symfony\Component\Serializer\Normalizer\ArrayDenormalizer::class,
+        Spatie\EventSourcing\Support\ObjectNormalizer::class,
+    ],
+
+    /*
+     * In production, you likely don't want the package to auto-discover the event handlers
      * on every request. The package can cache all registered event handlers.
-     * More info: https://docs.spatie.be/laravel-event-sourcing/v7/advanced-usage/discovering-projectors-and-reactors
+     * More info:
+     * https://spatie.be/docs/laravel-event-sourcing/v7/advanced-usage/discovering-projectors-and-reactors#content-caching-discovered-projectors-and-reactors
      *
      * Here you can specify where the cache should be stored.
      */
-    'cache_path' => storage_path('app/event-sourcing'),
+    'cache_path' => base_path('bootstrap/cache'),
+
+    /*
+     * When storable events are fired from aggregates roots, the package can fire off these
+     * events as regular events as well.
+     */
+
+    'dispatch_events_from_aggregate_roots' => false,
 ];
 ```
 


### PR DESCRIPTION
I just copied from the published config. The one at https://spatie.be was showing `use` statements at the top of the file and they were all formatted into a single line without breaks.

The actual config just uses fully qualified class names.