### PR TITLE
Use class map name when querying event class

### DIFF
--- a/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
+++ b/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
@@ -3,6 +3,8 @@
 namespace Spatie\EventSourcing\StoredEvents\Models;
 
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+use Spatie\EventSourcing\StoredEvents\StoredEvent;
 
 /**
  * @method \Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEventCollection get
@@ -32,7 +34,10 @@ class EloquentStoredEventQueryBuilder extends Builder
 
     public function whereEvent(string ...$eventClasses): self
     {
-        $this->whereIn('event_class', $eventClasses);
+        $this->whereIn(
+            'event_class',
+            Arr::map($eventClasses, static fn (string $eventClass): string => StoredEvent::getEventClass($eventClass)),
+        );
 
         return $this;
     }

--- a/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
+++ b/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
@@ -34,10 +34,10 @@ class EloquentStoredEventQueryBuilder extends Builder
 
     public function whereEvent(string ...$eventClasses): self
     {
-        $this->whereIn(
-            'event_class',
-            Arr::map($eventClasses, static fn (string $eventClass): string => StoredEvent::getEventClass($eventClass)),
-        );
+        $this->whereIn('event_class', array_map(
+            static fn (string $eventClass): string => StoredEvent::getEventClass($eventClass),
+            $eventClasses,
+        ));
 
         return $this;
     }

--- a/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
+++ b/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
@@ -35,7 +35,7 @@ class EloquentStoredEventQueryBuilder extends Builder
     public function whereEvent(string ...$eventClasses): self
     {
         $this->whereIn('event_class', array_map(
-            static fn (string $eventClass): string => StoredEvent::getEventClass($eventClass),
+           fn (string $eventClass): string => StoredEvent::getEventClass($eventClass),
             $eventClasses,
         ));
 

--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -150,7 +150,7 @@ class StoredEvent implements Arrayable
         return Arr::get(config('event-sourcing.event_class_map', []), $class, $class);
     }
 
-    protected static function getEventClass(string $class): string
+    public static function getEventClass(string $class): string
     {
         $map = config('event-sourcing.event_class_map', []);
 


### PR DESCRIPTION
When using an `event_class_map` and querying `->whereEvent(...)`, all given events should be mapped to their corresponding value before querying the database.