### PR TITLE
Only Dispatch If Event Has Async Handler

### DIFF
--- a/src/StoredEvents/StoredEvent.php
+++ b/src/StoredEvents/StoredEvent.php
@@ -104,7 +104,7 @@ class StoredEvent implements Arrayable
         /** @var \Spatie\EventSourcing\EventHandlers\EventHandlerCollection $eventHandlers */
         $eventHandlers = Projectionist::allEventHandlers();
 
-        return $eventHandlers->asyncEventHandlers()->count() > 0;
+        return $eventHandlers->forEvent($this)->asyncEventHandlers()->isNotEmpty();
     }
 
     protected function instantiateEvent(?ShouldBeStored $originalEvent): void

--- a/tests/TestClasses/Projectors/QueuedProjector.php
+++ b/tests/TestClasses/Projectors/QueuedProjector.php
@@ -3,7 +3,11 @@
 namespace Spatie\EventSourcing\Tests\TestClasses\Projectors;
 
 use Illuminate\Contracts\Queue\ShouldQueue;
+use Spatie\EventSourcing\Tests\TestClasses\Events\MoneyAddedEventWithQueueOverride;
 
 class QueuedProjector extends BalanceProjector implements ShouldQueue
 {
+    public function onMoneyAddedEventWithQueueOverride(MoneyAddedEventWithQueueOverride $event)
+    {
+    }
 }


### PR DESCRIPTION
This PR modifies the condition under which the handle stored event job is dispatched to the queue. 

With the pre-existing behavior, a job is dispatched each time an event persists if the projectionist has any async handlers registered, even if the specific event is irrelevant to all async handlers.

My application has certain events that contain a lot of data. These events do not have async handlers. Serializing these events to the queue (for what is ultimately a noop job) has resulted in errors due to SQS payload limits.

I also have some high-volume events that do not have async handlers, leading to unnecessary excessive queue throughput.

This change ensures a job is only dispatched if the fired event has async handlers.