### PR TITLE
Register optimize commands

### DIFF
--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -47,6 +47,14 @@ class EventSourcingServiceProvider extends PackageServiceProvider
         Event::subscribe(EventSubscriber::class);
 
         $this->discoverEventHandlers();
+
+        if (method_exists($this, 'optimizes')) {
+            $this->optimizes(
+                optimize: 'event-sourcing:cache-event-handlers',
+                clear: 'event-sourcing:clear-cached-event-handlers',
+                key: 'laravel-event-sourcing',
+            );
+        }
     }
 
     public function packageRegistered(): void


### PR DESCRIPTION
[Newly introduced in Laravel 11.27](https://github.com/laravel/framework/pull/52928), packages can now register the commands that should run during the `optimize` phase of deployment.

This PR adds the recommended steps for optimizing whenever it's available.