### PR TITLE
update command name to match class name

### DIFF
--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -51,7 +51,7 @@ class EventSourcingServiceProvider extends PackageServiceProvider
         if (method_exists($this, 'optimizes')) {
             $this->optimizes(
                 optimize: 'event-sourcing:cache-event-handlers',
-                clear: 'event-sourcing:clear-cached-event-handlers',
+                clear: 'event-sourcing:clear-event-handlers',
                 key: 'laravel-event-sourcing',
             );
         }


### PR DESCRIPTION
### Description
This PR aims to fix a problem in the `EventSourcingServiceProvider:54`, where the clear command is typed differently from the command signature.

<img width="677" alt="Screenshot 2024-10-10 at 22 43 39" src="https://github.com/user-attachments/assets/f12fe4f1-1429-42ec-bff8-46aaa9f7d70b">


### Fixed Error when running `optimize:clear`
<img width="1594" alt="Screenshot 2024-10-10 at 22 44 15" src="https://github.com/user-attachments/assets/d1ec2bae-249e-4f5a-901d-2bb28976fbfe">
