### PR TITLE
PHP 8.4 explicit null types

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.2, 8.1, 8.0]
+        php: [8.4, 8.2, 8.1, 8.0]
         laravel: ['9.*', '10.*', '11.*']
         dependency-version: [prefer-lowest, prefer-stable]
         include:

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -311,7 +311,7 @@ abstract class AggregateRoot
         return $this->entities;
     }
 
-    public static function fake(string $uuid = null): FakeAggregateRoot
+    public static function fake(?string $uuid = null): FakeAggregateRoot
     {
         $uuid ??= (string) Str::uuid();
 

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -70,7 +70,7 @@ class Projectionist
         return $this->projectors->merge($this->reactors);
     }
 
-    public function withoutEventHandlers(array $eventHandlers = null): Projectionist
+    public function withoutEventHandlers(?array $eventHandlers = null): Projectionist
     {
         if (is_null($eventHandlers)) {
             $this->projectors = new EventHandlerCollection();

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -38,7 +38,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         return $eloquentStoredEvent->toStoredEvent();
     }
 
-    public function retrieveAll(string $uuid = null): LazyCollection
+    public function retrieveAll(?string $uuid = null): LazyCollection
     {
         $query = $this->getQuery();
 
@@ -49,7 +49,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         return $query->orderBy('id')->cursor()->map(fn (EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }
 
-    public function retrieveAllStartingFrom(int $startingFrom, string $uuid = null): LazyCollection
+    public function retrieveAllStartingFrom(int $startingFrom, ?string $uuid = null): LazyCollection
     {
         $query = $this->prepareEventModelQuery($startingFrom, $uuid);
 
@@ -61,7 +61,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         return $lazyCollection->map(fn (EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }
 
-    public function countAllStartingFrom(int $startingFrom, string $uuid = null): int
+    public function countAllStartingFrom(int $startingFrom, ?string $uuid = null): int
     {
         return $this->prepareEventModelQuery($startingFrom, $uuid)->count('id');
     }
@@ -78,7 +78,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
             ->map(fn (EloquentStoredEvent $storedEvent) => $storedEvent->toStoredEvent());
     }
 
-    public function persist(ShouldBeStored $event, string $uuid = null): StoredEvent
+    public function persist(ShouldBeStored $event, ?string $uuid = null): StoredEvent
     {
         /** @var EloquentStoredEvent $eloquentStoredEvent */
         $eloquentStoredEvent = new $this->storedEventModel();
@@ -121,7 +121,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
         return $eloquentStoredEvent->toStoredEvent();
     }
 
-    public function persistMany(array $events, string $uuid = null): LazyCollection
+    public function persistMany(array $events, ?string $uuid = null): LazyCollection
     {
         $storedEvents = [];
 
@@ -166,7 +166,7 @@ class EloquentStoredEventRepository implements StoredEventRepository
                 ->max('aggregate_version') ?? 0;
     }
 
-    private function prepareEventModelQuery(int $startingFrom, string $uuid = null): Builder
+    private function prepareEventModelQuery(int $startingFrom, ?string $uuid = null): Builder
     {
         $query = $this->getQuery()->startingFrom($startingFrom);
 

--- a/src/StoredEvents/Repositories/StoredEventRepository.php
+++ b/src/StoredEvents/Repositories/StoredEventRepository.php
@@ -10,17 +10,17 @@ interface StoredEventRepository
 {
     public function find(int $id): StoredEvent;
 
-    public function retrieveAll(string $uuid = null): LazyCollection;
+    public function retrieveAll(?string $uuid = null): LazyCollection;
 
-    public function retrieveAllStartingFrom(int $startingFrom, string $uuid = null): LazyCollection;
+    public function retrieveAllStartingFrom(int $startingFrom, ?string $uuid = null): LazyCollection;
 
     public function retrieveAllAfterVersion(int $aggregateVersion, string $aggregateUuid): LazyCollection;
 
-    public function countAllStartingFrom(int $startingFrom, string $uuid = null): int;
+    public function countAllStartingFrom(int $startingFrom, ?string $uuid = null): int;
 
-    public function persist(ShouldBeStored $event, string $uuid = null): StoredEvent;
+    public function persist(ShouldBeStored $event, ?string $uuid = null): StoredEvent;
 
-    public function persistMany(array $events, string $uuid = null): LazyCollection;
+    public function persistMany(array $events, ?string $uuid = null): LazyCollection;
 
     public function update(StoredEvent $storedEvent): StoredEvent;
 

--- a/src/Support/CarbonNormalizer.php
+++ b/src/Support/CarbonNormalizer.php
@@ -13,7 +13,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritdoc
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): string
+    public function normalize(mixed $object, ?string $format = null, array $context = []): string
     {
         if (! $object instanceof CarbonInterface) {
             throw new InvalidArgumentException('Cannot serialize an object that is not a CarbonInterface in CarbonNormalizer.');
@@ -25,7 +25,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritdoc
      */
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return $data instanceof CarbonInterface;
     }
@@ -33,7 +33,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritDoc
      */
-    public function denormalize(mixed $data, string $class, string $format = null, array $context = []): CarbonInterface
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): CarbonInterface
     {
         return Date::parse($data);
     }
@@ -41,7 +41,7 @@ class CarbonNormalizer implements NormalizerInterface, DenormalizerInterface
     /**
      * @inheritDoc
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return is_a($type, CarbonInterface::class, true);
     }

--- a/src/Support/ModelIdentifierNormalizer.php
+++ b/src/Support/ModelIdentifierNormalizer.php
@@ -19,7 +19,7 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function normalize(mixed $object, string $format = null, array $context = []): array
+    public function normalize(mixed $object, ?string $format = null, array $context = []): array
     {
         if (! $this->supportsNormalization($object)) {
             throw new InvalidArgumentException('Cannot serialize an object that is not a QueueableEntity or QueueableCollection in ModelIdentifierNormalizer.');
@@ -31,7 +31,7 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function supportsNormalization(mixed $data, string $format = null, array $context = []): bool
+    public function supportsNormalization(mixed $data, ?string $format = null, array $context = []): bool
     {
         return ($data instanceof QueueableEntity || $data instanceof QueueableCollection);
     }
@@ -39,7 +39,7 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function denormalize(mixed $data, string $type, string $format = null, array $context = []): Collection|Model
+    public function denormalize(mixed $data, string $type, ?string $format = null, array $context = []): Collection|Model
     {
         $identifier = $data instanceof ModelIdentifier
             ? $data
@@ -51,7 +51,7 @@ class ModelIdentifierNormalizer implements NormalizerInterface, DenormalizerInte
     /**
      * @inheritdoc
      */
-    public function supportsDenormalization(mixed $data, string $type, string $format = null, array $context = []): bool
+    public function supportsDenormalization(mixed $data, string $type, ?string $format = null, array $context = []): bool
     {
         return $this->normalizedDataIsModelIdentifier($data)
             && $this->isNormalizedToModelIdentifier($type);


### PR DESCRIPTION
Hi, this PR removes the deprecation notices regarding the implicitly nullable parameters.