### PR TITLE
Fix Remaining Nullable Parameter Definitions

### DIFF
--- a/docs/advanced-usage/using-your-own-event-serializer.md
+++ b/docs/advanced-usage/using-your-own-event-serializer.md
@@ -34,7 +34,7 @@ the currency.
 ```
 class UpgradeSerializer extends JsonEventSerializer
 {
-    public function deserialize(string $eventClass, string $json, string $metadata = null): ShouldBeStored
+    public function deserialize(string $eventClass, string $json, ?string $metadata = null): ShouldBeStored
     {
         $event = parent::deserialize($eventClass, $json, $metadata);
 

--- a/src/EventSerializers/EventSerializer.php
+++ b/src/EventSerializers/EventSerializer.php
@@ -12,6 +12,6 @@ interface EventSerializer
         string $eventClass,
         string $json,
         int $version,
-        string $metadata = null
+        ?string $metadata = null
     ): ShouldBeStored;
 }

--- a/src/EventSerializers/JsonEventSerializer.php
+++ b/src/EventSerializers/JsonEventSerializer.php
@@ -37,7 +37,7 @@ class JsonEventSerializer implements EventSerializer
         string $eventClass,
         string $json,
         int $version,
-        string $metadata = null
+        ?string $metadata = null
     ): ShouldBeStored {
         return $this->serializer->deserialize($json, $eventClass, 'json');
     }


### PR DESCRIPTION
Fixed the remaining missing ?string definitions for the metadata parameter in EventSerializer, JsonEventSerializer, and the documentation example for consistency.