### PR TITLE
feat: add eloquent stored event generic types for collection and query builder

### DIFF
--- a/src/StoredEvents/Models/EloquentStoredEvent.php
+++ b/src/StoredEvents/Models/EloquentStoredEvent.php
@@ -69,11 +69,17 @@ class EloquentStoredEvent extends Model
         return SchemalessAttributes::createForModel($this, 'meta_data');
     }
 
+    /**
+     * @return EloquentStoredEventQueryBuilder<$this>
+     */
     public function newEloquentBuilder($query): EloquentStoredEventQueryBuilder
     {
         return new EloquentStoredEventQueryBuilder($query);
     }
 
+    /**
+     * @return EloquentStoredEventCollection<$this>
+     */
     public function newCollection(array $models = []): EloquentStoredEventCollection
     {
         return new EloquentStoredEventCollection($models);

--- a/src/StoredEvents/Models/EloquentStoredEventCollection.php
+++ b/src/StoredEvents/Models/EloquentStoredEventCollection.php
@@ -5,6 +5,11 @@ namespace Spatie\EventSourcing\StoredEvents\Models;
 use Illuminate\Database\Eloquent\Collection as EloquentCollection;
 use Illuminate\Support\Collection;
 
+/**
+ * @template TEloquentStoredEvent of EloquentStoredEvent
+ *
+ * @extends EloquentCollection<array-key, TEloquentStoredEvent>
+ */
 class EloquentStoredEventCollection extends EloquentCollection
 {
     /**

--- a/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
+++ b/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
@@ -6,7 +6,11 @@ use Illuminate\Database\Eloquent\Builder;
 use Spatie\EventSourcing\StoredEvents\StoredEvent;
 
 /**
- * @method \Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEventCollection get
+ * @template TEloquentStoredEvent of EloquentStoredEvent
+ *
+ * @method \Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEventCollection<EloquentStoredEvent> get()
+ *
+ * @extends Builder<TEloquentStoredEvent>
  */
 class EloquentStoredEventQueryBuilder extends Builder
 {


### PR DESCRIPTION
This is useful when using PHPStan in your project in combination with the `EventQuery` classes.