### PR TITLE
Fix the CarbonImmutable's toJson method to always convert to UTF time

### DIFF
--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -98,13 +98,18 @@ class EloquentStoredEventRepository implements StoredEventRepository
             $serializerClass = $serializerAttribute->newInstance()->serializerClass;
         }
 
+        $metaData = $event->metaData();
+        if ($metaDataCreatedAt = data_get($metaData, MetaData::CREATED_AT)) {
+            $metaData[MetaData::CREATED_AT] = $metaDataCreatedAt->toDateTimeString();
+        }
+
         $eloquentStoredEvent->setRawAttributes([
             'event_properties' => app($serializerClass)->serialize(clone $event),
             'aggregate_uuid' => $uuid,
             'aggregate_version' => $event->aggregateRootVersion(),
             'event_version' => $event->eventVersion(),
             'event_class' => $this->getEventClass(get_class($event)),
-            'meta_data' => json_encode($event->metaData() + [
+            'meta_data' => json_encode($metaData + [
                 MetaData::CREATED_AT => $createdAt->toDateTimeString(),
             ]),
             'created_at' => $createdAt,

--- a/tests/MetaDataCreatedAtTest.php
+++ b/tests/MetaDataCreatedAtTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\EventSourcing\Tests;
+
+use Carbon\Carbon;
+use Carbon\CarbonImmutable;
+use Spatie\EventSourcing\Enums\MetaData;
+use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
+use Spatie\EventSourcing\StoredEvents\Repositories\EloquentStoredEventRepository;
+use Spatie\EventSourcing\Tests\TestClasses\AggregateRoots\StorableEvents\MoneyAdded;
+use function PHPUnit\Framework\assertEquals;
+
+it('correctly handles created_at in meta data', function () {
+    $now = CarbonImmutable::now()->setTimezone('Asia/Singapore');
+    $customCreatedAt = $now;
+    $event = new MoneyAdded(100);
+    $event->setMetaData([
+        MetaData::CREATED_AT => $customCreatedAt,
+    ]);
+
+    $repository = app(EloquentStoredEventRepository::class);
+    $storedEvent = $repository->persist($event, 'test-uuid');
+
+    $eloquentStoredEvent = EloquentStoredEvent::query()->find($storedEvent->id);
+    $shouldBeStoredEvent = $eloquentStoredEvent->toStoredEvent()->event;
+    assertEquals($shouldBeStoredEvent->createdAt()->toDateTimeString(), $customCreatedAt->toDateTimeString());
+});


### PR DESCRIPTION
The persist code of `Spatie\EventSourcing\StoredEvents\Repositories\EloquentStoredEventRepository`.

```php
public function persist(ShouldBeStored $event, string $uuid = null): StoredEvent
    {
       .....
        $eloquentStoredEvent->setRawAttributes([
            'event_properties' => app($serializerClass)->serialize(clone $event),
            'aggregate_uuid' => $uuid,
            'aggregate_version' => $event->aggregateRootVersion(),
            'event_version' => $event->eventVersion(),
            'event_class' => $this->getEventClass(get_class($event)),
            'meta_data' => json_encode($event->metaData() + [
                MetaData::CREATED_AT => $createdAt->toDateTimeString(),
            ]),
            'created_at' => $createdAt,
        ]);
        .......
    }
```

If I set the timezone in `config/app.php` to a non-UTC timezone, `json_encode` will always set the `created-at` in `meta_data` to the UTC timezone, resulting in inconsistent timestamps.