### PR TITLE
feat:  Add `ignoringDirectories` to filter `Providers`, `route` directory

### DIFF
--- a/config/event-sourcing.php
+++ b/config/event-sourcing.php
@@ -11,6 +11,18 @@ return [
     ],
 
     /*
+     * These directories will be ignored when scanning for projectors and reactors.
+     */
+    'auto_discover_projectors_and_reactors_should_ignore_directories' => [
+        app()->path('Providers'),
+        app()->path('Console'),
+        app()->path('Events'),
+        app()->path('Listeners'),
+        app()->path('Jobs'),
+        app()->path('Notifications'),
+    ],
+
+    /*
      * This directory will be used as the base path when scanning
      * for projectors and reactors.
      */

--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -75,7 +75,7 @@ class EventSourcingServiceProvider extends PackageServiceProvider
 
         $this->app->singleton(StoredEventRepository::class, config('event-sourcing.stored_event_repository'));
 
-        $this->app->singleton(EventSubscriber::class, fn () => new EventSubscriber(config('event-sourcing.stored_event_repository')));
+        $this->app->singleton(EventSubscriber::class, fn() => new EventSubscriber(config('event-sourcing.stored_event_repository')));
 
         $this->app
             ->when(ReplayCommand::class)
@@ -101,12 +101,13 @@ class EventSourcingServiceProvider extends PackageServiceProvider
             ->within(config('event-sourcing.auto_discover_projectors_and_reactors'))
             ->useBasePath(config('event-sourcing.auto_discover_base_path', base_path()))
             ->ignoringFiles(Composer::getAutoloadedFiles(base_path('composer.json')))
+            ->ignoringDirectories(config('event-sourcing.auto_discover_projectors_and_reactors_should_ignore_directories'))
             ->addToProjectionist($projectionist);
     }
 
     protected function getCachedEventHandlers(): ?array
     {
-        $cachedEventHandlersPath = config('event-sourcing.cache_path').'/event-handlers.php';
+        $cachedEventHandlersPath = config('event-sourcing.cache_path') . '/event-handlers.php';
 
         if (! file_exists($cachedEventHandlersPath)) {
             return null;

--- a/tests/DiscoversEventHandlersTest.php
+++ b/tests/DiscoversEventHandlersTest.php
@@ -65,3 +65,46 @@ it('can get all classes that have event handlers', function () {
         TestReactor::class,
     ], $registeredReactors);
 });
+
+it('can ignore directories when discovering event handlers', function () {
+    /** @var \Spatie\EventSourcing\Projectionist $projectionist */
+    $projectionist = app(Projectionist::class);
+
+    $pathToComposerJson = __DIR__.'/../composer.json';
+    $subdirectoryPath = __DIR__.'/TestClasses/AutoDiscoverEventHandlers/Subdirectory';
+
+    (new DiscoverEventHandlers())
+        ->within([__DIR__.'/TestClasses/AutoDiscoverEventHandlers'])
+        ->useBasePath(getDiscoveryBasePath())
+        ->useRootNamespace('Spatie\EventSourcing\\')
+        ->ignoringFiles(Composer::getAutoloadedFiles($pathToComposerJson))
+        ->ignoringDirectories([$subdirectoryPath])
+        ->addToProjectionist($projectionist);
+
+    $registeredProjectors = $projectionist
+        ->getProjectors()
+        ->toBase()
+        ->map(function (EventHandler $eventHandler) {
+            return get_class($eventHandler);
+        })
+        ->values()
+        ->toArray();
+
+    assertEqualsCanonicalizing([
+        TestQueuedProjector::class,
+        TestProjector::class,
+    ], $registeredProjectors);
+
+    $registeredReactors = $projectionist
+        ->getReactors()
+        ->toBase()
+        ->map(function (EventHandler $eventHandler) {
+            return get_class($eventHandler);
+        })
+        ->values()
+        ->toArray();
+
+    assertEqualsCanonicalizing([
+        TestReactor::class,
+    ], $registeredReactors);
+});


### PR DESCRIPTION
@freekmurze  The `addToProjectionist` code of `Spatie\EventSourcing\Support\DiscoverEventHandlers`.

```php
public function addToProjectionist(Projectionist $projectionist)
{
    if (empty($this->directories)) {
        return;
    }

    $files = (new Finder())->files()->in($this->directories);
    
    return collect($files)
        ->reject(fn (SplFileInfo $file) => in_array($file->getPathname(), $this->ignoredFiles))
        ->map(fn (SplFileInfo $file) => $this->fullQualifiedClassNameFromFile($file))
        ->filter(fn (string $eventHandlerClass) => is_subclass_of($eventHandlerClass, EventHandler::class))
        ->filter(fn (string $eventHandlerClass) => (new ReflectionClass($eventHandlerClass))->isInstantiable())
        ->pipe(function (Collection $eventHandlers) use ($projectionist) {
            $projectionist->addEventHandlers($eventHandlers->toArray());
        });
}

```


### Case 1

The `addToProjectionist` method scans the entire `app` directory. The composer package `laravel/telescope` is not installed in production environment, but executing `is_subclass_of($eventHandlerClass, EventHandler::class)` results in an error `Class "Laravel\Telescope\TelescopeApplicationServiceProvider" not found`, because `App\Providers\TelescopeServiceProvider` extends `Laravel\Telescope\TelescopeApplicationServiceProvider`.

<img width="1786" alt="image" src="https://github.com/user-attachments/assets/84ef9007-0c83-4cb2-87ea-378c1437a27c" />

<img width="1406" alt="image" src="https://github.com/user-attachments/assets/3ad3f38a-7f0a-486c-b20d-ee5b2dcc8304" />

<img width="1129" alt="image" src="https://github.com/user-attachments/assets/f4689e99-86aa-44c1-93c3-a81fe7b32320" />


### Case 2

When scanning all route files in `app/Api/routes/`, `is_subclass_of` triggers autoloading. The autoload mechanism causes routes to be registered. This is equivalent to executing `require app/Api/routes/bookings.php`, which causes `Route::resource('bookings', BookingsController::class)->only(['store', 'destroy'])` to be executed

<img width="1579" alt="image" src="https://github.com/user-attachments/assets/8c77d2f2-8cb9-406a-b38a-0133c5487d59" />

