### PR TITLE
Case insensitive CouldNotPersistAggregate::invalidVersion detection

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -143,7 +143,7 @@ abstract class AggregateRoot
                     $this->uuid(),
                 );
         } catch (QueryException $exception) {
-            if (! str_contains($exception->getMessage(), 'Duplicate')) {
+            if (! str_contains(strtolower($exception->getMessage()), 'duplicate')) {
                 throw $exception;
             }
 

--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -4,6 +4,7 @@ namespace Spatie\EventSourcing\AggregateRoots;
 
 use Carbon\CarbonImmutable;
 use Illuminate\Database\QueryException;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\LazyCollection;
@@ -143,7 +144,7 @@ abstract class AggregateRoot
                     $this->uuid(),
                 );
         } catch (QueryException $exception) {
-            if (! str_contains(strtolower($exception->getMessage()), 'duplicate')) {
+            if (! ($exception instanceof UniqueConstraintViolationException || str_contains($exception->getMessage(), 'Duplicate'))) {
                 throw $exception;
             }
 


### PR DESCRIPTION
With Postgres, the error message thrown for a unique constraint violation doesn't have a capital D

```
SQLSTATE[  23505]: Unique violation:   7 ERROR:  duplicate key value violates unique constraint 
```