### PR TITLE
[Docs] Add Missing Version Property in Event Serializers

### DIFF
--- a/docs/advanced-usage/using-your-own-event-serializer.md
+++ b/docs/advanced-usage/using-your-own-event-serializer.md
@@ -9,7 +9,7 @@ You can specify your own serializer by creating a class that implements `Spatie\
 
 This is the content of the `EventSerializer` interface:
 
-```
+```php
 namespace Spatie\EventSourcing\EventSerializers;
 
 use Spatie\EventSourcing\ShouldBeStored;
@@ -31,17 +31,17 @@ Using our larabank example, let's imagine that we've gone international and our 
 international payments. Our `MoneyAdded` events will need to have an additional field for
 the currency.
 
-```
-use App\Events\PaymentCreated;
+```php
+use App\Events\MoneyAdded;
 
 class UpgradeSerializer extends JsonEventSerializer
 {
     public function deserialize(string $eventClass, string $json, int $version, ?string $metadata = null): ShouldBeStored
     {
-        $event = parent::deserialize($eventClass, $json, $metadata);
+        $event = parent::deserialize($eventClass, $json, $version, $metadata);
 
         // all currency was USD before we started accepting other currencies
-        if ($eventClass === PaymentCreated::class && empty($event->currency)) {
+        if ($eventClass === MoneyAdded::class && empty($event->currency)) {
             $event->currency = 'USD';
         }
 

--- a/docs/advanced-usage/using-your-own-event-serializer.md
+++ b/docs/advanced-usage/using-your-own-event-serializer.md
@@ -18,7 +18,7 @@ interface EventSerializer
 {
     public function serialize(ShouldBeStored $event): string;
 
-    public function deserialize(string $eventClass, string $json, string $metadata): ShouldBeStored;
+    public function deserialize(string $eventClass, string $json, int $version, ?string $metadata = null): ShouldBeStored;
 }
 ```
 
@@ -32,14 +32,16 @@ international payments. Our `MoneyAdded` events will need to have an additional 
 the currency.
 
 ```
+use App\Events\PaymentCreated;
+
 class UpgradeSerializer extends JsonEventSerializer
 {
-    public function deserialize(string $eventClass, string $json, ?string $metadata = null): ShouldBeStored
+    public function deserialize(string $eventClass, string $json, int $version, ?string $metadata = null): ShouldBeStored
     {
         $event = parent::deserialize($eventClass, $json, $metadata);
 
         // all currency was USD before we started accepting other currencies
-        if (empty($event->currency)) {
+        if ($eventClass === PaymentCreated::class && empty($event->currency)) {
             $event->currency = 'USD';
         }
 


### PR DESCRIPTION
### [Docs] Add Missing Version Property in Event Serializers

**Context:**  
The documentation for using a custom event serializer was outdated and inconsistent with the updated `EventSerializer` interface.

**Changes Introduced:**  
- Added PHP syntax highlighting to code blocks for better readability.
- Updated the `EventSerializer` interface method signature:
  - `deserialize` now accepts an additional `int $version` parameter.
  - Made `$metadata` optional and nullable.
- Adjusted the example `UpgradeSerializer` class:
  - Updated its `deserialize` method signature to match the new interface.
  - Added a conditional check to apply currency defaulting logic only for the `MoneyAdded` event class.

**Impact:**  
This update ensures developers extending or overriding the event serializer have accurate references, No breaking changes to codebase functionality.