### PR TITLE
Filter out non-existent classes from cached event handlers

### DIFF
--- a/src/EventSourcingServiceProvider.php
+++ b/src/EventSourcingServiceProvider.php
@@ -92,7 +92,12 @@ class EventSourcingServiceProvider extends PackageServiceProvider
         $cachedEventHandlers = $this->getCachedEventHandlers();
 
         if (! is_null($cachedEventHandlers)) {
-            $projectionist->addEventHandlers($cachedEventHandlers);
+            // Filter out non-existent classes from cached event handlers
+            $validEventHandlers = array_filter($cachedEventHandlers, function ($eventHandlerClass) {
+                return class_exists($eventHandlerClass);
+            });
+
+            $projectionist->addEventHandlers($validEventHandlers);
 
             return;
         }


### PR DESCRIPTION
@freekmurze 
1. When deployed to production, the file will execute `php artisan optimize` to generate the `event-handlers.php` file.
2. Due to requirement changes, I deleted the `App\\Bookings\\Projector\\BookingsProjector` class, but the event-handlers.php file is not being updated.
3. During redeployment, an exception was triggered because `App\Bookings\Projector\BookingsProjector` is still registered in the `event-handlers.php` file, causing the `php artisan` command to fail and resulting in deployment failure.