### PR TITLE
Fix restorePartialState() being incorrectly assigned to dynamic property

### DIFF
--- a/src/AggregateRoots/AggregateRoot.php
+++ b/src/AggregateRoots/AggregateRoot.php
@@ -222,7 +222,7 @@ abstract class AggregateRoot
     {
         foreach ($state as $key => $value) {
             if (class_exists($key)) {
-                $this->$key = $this->restorePartialState($key, $value);
+                $this->restorePartialState($key, $value);
             } else {
                 $this->$key = $value;
             }


### PR DESCRIPTION
This line causes a depreciation notice to be issued:

```
Creation of dynamic property App\Domain\Orders\OrderAggregateRoot::$App\Domain\Orders\Partials\RollbackPartial is deprecated in vendor/spatie/laravel-event-sourcing/src/AggregateRoots/AggregateRoot.php on line 225
```

The current code sets void to the full class name. Since restorePartialState handles setting the property, i've removed the key assignment.