### PR TITLE
Event replay optimizations

### DIFF
--- a/src/Console/ReplayCommand.php
+++ b/src/Console/ReplayCommand.php
@@ -6,6 +6,7 @@ use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Collection;
 use Spatie\EventSourcing\Projectionist;
+use Spatie\EventSourcing\EventHandlers\Projectors\Projector;
 use Spatie\EventSourcing\StoredEvents\Repositories\StoredEventRepository;
 
 class ReplayCommand extends Command
@@ -67,7 +68,8 @@ class ReplayCommand extends Command
     public function replay(Collection $projectors, int $startingFrom, ?string $aggregateUuid = null): void
     {
         $repository = app(StoredEventRepository::class);
-        $replayCount = $repository->countAllStartingFrom($startingFrom, $aggregateUuid);
+        $events = $projectors->map(fn(Projector $projector) => $projector->getEventHandlingMethods()->keys())->flatten()->toArray();
+        $replayCount = $repository->countAllStartingFrom($startingFrom, $aggregateUuid, $events);
 
         if ($replayCount === 0) {
             $this->warn('There are no events to replay');

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -66,10 +66,8 @@ class EloquentStoredEventRepository implements StoredEventRepository
     public function runForAllStartingFrom(int $startingFrom, callable|\Closure $function, int $chunkSize = 1000, ?string $uuid = null, array $events = []): LazyCollection {
         $query = $this->prepareEventModelQuery($startingFrom, $uuid, $events);
 
-        /** @var LazyCollection $lazyCollection */
         $lazyCollection = $query
-            ->orderBy('id')
-            ->lazyById();
+            ->orderBy('id');
 
         return $lazyCollection->chunk($chunkSize, function (Collection $events) use ($function) {
             foreach ($events as $event) {

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -66,10 +66,10 @@ class EloquentStoredEventRepository implements StoredEventRepository
     public function runForAllStartingFrom(int $startingFrom, callable|\Closure $function, int $chunkSize = 1000, ?string $uuid = null, array $events = []): LazyCollection {
         $query = $this->prepareEventModelQuery($startingFrom, $uuid, $events);
 
-        $lazyCollection = $query
+        $query = $query
             ->orderBy('id');
 
-        return $lazyCollection->chunk($chunkSize, function (Collection $events) use ($function) {
+        return $query->chunk($chunkSize, function (Collection $events) use ($function) {
             foreach ($events as $event) {
                 $storedEVent = $event->toStoredEvent();
                 $function($storedEVent);

--- a/src/StoredEvents/Repositories/StoredEventRepository.php
+++ b/src/StoredEvents/Repositories/StoredEventRepository.php
@@ -12,11 +12,13 @@ interface StoredEventRepository
 
     public function retrieveAll(?string $uuid = null): LazyCollection;
 
-    public function retrieveAllStartingFrom(int $startingFrom, ?string $uuid = null): LazyCollection;
+    public function retrieveAllStartingFrom(int $startingFrom, ?string $uuid = null, array $events = []): LazyCollection;
+
+    public function runForAllStartingFrom(int $startingFrom, callable|\Closure $function, int $chunkSize = 1000, ?string $uuid = null, array $events = []): LazyCollection;
 
     public function retrieveAllAfterVersion(int $aggregateVersion, string $aggregateUuid): LazyCollection;
 
-    public function countAllStartingFrom(int $startingFrom, ?string $uuid = null): int;
+    public function countAllStartingFrom(int $startingFrom, ?string $uuid = null, array $events = []): int;
 
     public function persist(ShouldBeStored $event, ?string $uuid = null): StoredEvent;
 


### PR DESCRIPTION
This PR adds the ability replay only events related to the selected projectors, and uses ```chunk``` to optimize memory usage and avoid memory corruption bugs in PHP when replaying millions of events.