### PR TITLE
Projectionist: Don't stop handling events when catching exceptions

### DIFF
--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -264,7 +264,9 @@ class Projectionist
 
         $projectors
             ->sortBy(fn (EventHandler $eventHandler) => $eventHandler->getWeight($storedEvent))
-            ->each(fn (EventHandler $projector) => $this->callEventHandler($projector, $storedEvent));
+            ->each(function (EventHandler $projector) use ($storedEvent): void {
+                $this->callEventHandler($projector, $storedEvent);
+            });
 
         $this->isProjecting = false;
     }
@@ -273,7 +275,9 @@ class Projectionist
     {
         $reactors
             ->sortBy(fn (EventHandler $eventHandler) => $eventHandler->getWeight($storedEvent))
-            ->each(fn (EventHandler $reactor) => $this->callEventHandler($reactor, $storedEvent));
+            ->each(function (EventHandler $reactor) use ($storedEvent): void {
+                $this->callEventHandler($reactor, $storedEvent);
+            });
     }
 
     private function callEventHandler(EventHandler $eventHandler, StoredEvent $storedEvent): bool


### PR DESCRIPTION
According to the documentation in `config/event-sourcing.php:43-47`:

```
    /*
     * When a Projector or Reactor throws an exception the event Projectionist can catch it
     * so all other projectors and reactors can still do their work. The exception will
     * be passed to the `handleException` method on that Projector or Reactor.
     */
```

But if the feature is activated, the current implementation catches the exception _and_ aborts further event handling. This happens because the method returns false, and in this case the Laravel Collection stops the loop (see here 
[/Illuminate/Collections/Traits/EnumeratesValues.php#L268](https://github.com/laravel/framework/blob/920724c150c8d63fa5a96a5e3f0afe10f4e111bd/src/Illuminate/Collections/Traits/EnumeratesValues.php#L268)).

This creates a situation where the exceptions are ignored, but nevertheless the Projectionist stops calling the remaining projectors or reactors.