### PR TITLE
Fix metaData leaking into event_properties since Symfony Serializer v8.0.4

### DIFF
--- a/src/StoredEvents/ShouldBeStored.php
+++ b/src/StoredEvents/ShouldBeStored.php
@@ -7,12 +7,14 @@ use Carbon\CarbonImmutable;
 use ReflectionClass;
 use Spatie\EventSourcing\Attributes\EventVersion;
 use Spatie\EventSourcing\Enums\MetaData;
+use Symfony\Component\Serializer\Attribute\Ignore;
 
 #[AllowDynamicProperties]
 abstract class ShouldBeStored
 {
     protected array $metaData = [];
 
+    #[Ignore]
     public function eventVersion(): int
     {
         $versionAttribute = (new ReflectionClass($this))->getAttributes(EventVersion::class)[0] ?? null;
@@ -24,11 +26,13 @@ abstract class ShouldBeStored
         return $versionAttribute->newInstance()->version;
     }
 
+    #[Ignore]
     public function createdAt(): ?CarbonImmutable
     {
         return CarbonImmutable::make($this->metaData[MetaData::CREATED_AT] ?? null);
     }
 
+    #[Ignore]
     public function setCreatedAt(CarbonImmutable $createdAt): self
     {
         $this->metaData[MetaData::CREATED_AT] = $createdAt;
@@ -36,11 +40,13 @@ abstract class ShouldBeStored
         return $this;
     }
 
+    #[Ignore]
     public function aggregateRootUuid(): ?string
     {
         return $this->metaData[MetaData::AGGREGATE_ROOT_UUID] ?? null;
     }
 
+    #[Ignore]
     public function setAggregateRootUuid(string $uuid): self
     {
         $this->metaData[MetaData::AGGREGATE_ROOT_UUID] = $uuid;
@@ -48,11 +54,13 @@ abstract class ShouldBeStored
         return $this;
     }
 
+    #[Ignore]
     public function storedEventId(): ?int
     {
         return $this->metaData[MetaData::STORED_EVENT_ID] ?? null;
     }
 
+    #[Ignore]
     public function setStoredEventId(int $id): self
     {
         $this->metaData[MetaData::STORED_EVENT_ID] = $id;
@@ -60,11 +68,13 @@ abstract class ShouldBeStored
         return $this;
     }
 
+    #[Ignore]
     public function aggregateRootVersion(): ?int
     {
         return $this->metaData[MetaData::AGGREGATE_ROOT_VERSION] ?? null;
     }
 
+    #[Ignore]
     public function setAggregateRootVersion(int $version): self
     {
         $this->metaData[MetaData::AGGREGATE_ROOT_VERSION] = $version;
@@ -72,11 +82,13 @@ abstract class ShouldBeStored
         return $this;
     }
 
+    #[Ignore]
     public function metaData(): array
     {
         return $this->metaData;
     }
 
+    #[Ignore]
     public function setMetaData(array $metaData): self
     {
         $this->metaData = $metaData;

--- a/src/Support/ObjectNormalizer.php
+++ b/src/Support/ObjectNormalizer.php
@@ -6,7 +6,9 @@ use Symfony\Component\PropertyAccess\PropertyAccessorInterface;
 use Symfony\Component\PropertyInfo\Extractor\PhpDocExtractor;
 use Symfony\Component\PropertyInfo\PropertyTypeExtractorInterface;
 use Symfony\Component\Serializer\Mapping\ClassDiscriminatorResolverInterface;
+use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactory;
 use Symfony\Component\Serializer\Mapping\Factory\ClassMetadataFactoryInterface;
+use Symfony\Component\Serializer\Mapping\Loader\AttributeLoader;
 use Symfony\Component\Serializer\NameConverter\NameConverterInterface;
 use Symfony\Component\Serializer\Normalizer\AbstractObjectNormalizer as SymfonyAbstractObjectNormalizer;
 use Symfony\Component\Serializer\Normalizer\ObjectNormalizer as SymfonyObjectNormalizer;
@@ -18,6 +20,7 @@ class ObjectNormalizer extends SymfonyAbstractObjectNormalizer
     public function __construct(?ClassMetadataFactoryInterface $classMetadataFactory = null, ?NameConverterInterface $nameConverter = null, ?PropertyAccessorInterface $propertyAccessor = null, ?PropertyTypeExtractorInterface $propertyTypeExtractor = null, ?ClassDiscriminatorResolverInterface $classDiscriminatorResolver = null, ?callable $objectClassResolver = null, array $defaultContext = [])
     {
 
+        $classMetadataFactory = $classMetadataFactory ?? new ClassMetadataFactory(new AttributeLoader());
         $propertyTypeExtractor = $propertyTypeExtractor ?? new PhpDocExtractor();
 
         $this->normalizer = new SymfonyObjectNormalizer(

--- a/tests/EventSerializers/EventSerializerTest.php
+++ b/tests/EventSerializers/EventSerializerTest.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Carbon\CarbonInterface;
 use DateTimeImmutable;
 
+use function PHPUnit\Framework\assertArrayNotHasKey;
 use function PHPUnit\Framework\assertEquals;
 use function PHPUnit\Framework\assertInstanceOf;
 
@@ -33,6 +34,18 @@ it('can serialize a plain event', function () {
     assertEquals([
         'value' => 'test',
     ], $array);
+});
+
+it('does not serialize metaData into event properties', function () {
+    $event = new EventWithoutSerializedModels('test');
+    $event->setMetaData(['aggregate-root-uuid' => 'some-uuid']);
+
+    $json = $this->eventSerializer->serialize($event);
+
+    $array = json_decode($json, true);
+
+    assertEquals(['value' => 'test'], $array);
+    assertArrayNotHasKey('metaData', $array);
 });
 
 it('can serialize an event containing a model', function () {


### PR DESCRIPTION
## Summary
- Fixes `metaData` (and other `ShouldBeStored` internal properties) leaking into the `event_properties` column when using Symfony Serializer v8.0.4+
- Uses Symfony's `#[Ignore]` attribute on all `ShouldBeStored` methods to exclude them from serialization
- Configures `ClassMetadataFactory` with `AttributeLoader` in the custom `ObjectNormalizer` so the `#[Ignore]` attributes are read

Closes #518

## Test plan
- [x] Added test asserting `metaData` is not present in serialized event properties
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)