### PR TITLE
Constrain phpunit-snapshot-assertions to <5.2 to fix CI

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "phpunit/phpunit": "^9.5.10|^10.5|^11.5.3",
         "spatie/fork": "^1.2.4",
         "spatie/pest-plugin-snapshots": "^1.1|^2.2",
-        "spatie/phpunit-snapshot-assertions": "^4.0|^5.1.8"
+        "spatie/phpunit-snapshot-assertions": "^4.0|^5.1.8 <5.2"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary
- Constrains `spatie/phpunit-snapshot-assertions` to `^5.1.8 <5.2` to fix the CI failure
- `pest-plugin-snapshots` v2.2.x overrides `SnapshotIdAware` via `exclude-from-classmap`, but `phpunit-snapshot-assertions` v5.2.0 moved `$snapshotIncrementor` from `MatchesSnapshots` into `SnapshotIdAware` — causing an undefined property error when the pest plugin's override takes precedence

## Test plan
- [x] All CI tests should now pass (the `CacheEventHandlersCommandTest` snapshot test was the only failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)