### PR TITLE
Use spatie/php-attribute-reader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,6 +30,7 @@
         "phpdocumentor/reflection-docblock": "^5.6.1",
         "spatie/better-types": "^1.0",
         "spatie/laravel-package-tools": "^1.19",
+        "spatie/php-attribute-reader": "^1.0",
         "spatie/laravel-schemaless-attributes": "^2.5.1",
         "symfony/finder": "^6.0|^7.2.2|^8.0",
         "symfony/polyfill-php82": ">=1.31",

--- a/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
+++ b/src/StoredEvents/Repositories/EloquentStoredEventRepository.php
@@ -6,14 +6,12 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Collection;
 use Illuminate\Support\LazyCollection;
-use ReflectionClass;
-use ReflectionException;
+use Spatie\Attributes\Attributes;
 use Spatie\EventSourcing\AggregateRoots\Exceptions\InvalidEloquentStoredEventModel;
 use Spatie\EventSourcing\Attributes\EventSerializer as EventSerializerAttribute;
 use Spatie\EventSourcing\Enums\MetaData;
 use Spatie\EventSourcing\EventSerializers\EventSerializer;
 use Spatie\EventSourcing\StoredEvents\Exceptions\EventClassMapMissing;
-use Spatie\EventSourcing\StoredEvents\Exceptions\InvalidStoredEvent;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEvent;
 use Spatie\EventSourcing\StoredEvents\Models\EloquentStoredEventQueryBuilder;
 use Spatie\EventSourcing\StoredEvents\ShouldBeStored;
@@ -109,16 +107,8 @@ class EloquentStoredEventRepository implements StoredEventRepository
 
         $createdAt = Carbon::now();
 
-        try {
-            $reflectionClass = new ReflectionClass(get_class($event));
-        } catch (ReflectionException) {
-            throw new InvalidStoredEvent();
-        }
-
-        $serializerClass = EventSerializer::class;
-        if ($serializerAttribute = $reflectionClass->getAttributes(EventSerializerAttribute::class)[0] ?? null) {
-            $serializerClass = $serializerAttribute->newInstance()->serializerClass;
-        }
+        $serializerAttribute = Attributes::get($event, EventSerializerAttribute::class);
+        $serializerClass = $serializerAttribute?->serializerClass ?? EventSerializer::class;
 
         $metaData = $event->metaData();
         if ($metaDataCreatedAt = data_get($metaData, MetaData::CREATED_AT)) {

--- a/src/StoredEvents/ShouldBeStored.php
+++ b/src/StoredEvents/ShouldBeStored.php
@@ -4,7 +4,7 @@ namespace Spatie\EventSourcing\StoredEvents;
 
 use AllowDynamicProperties;
 use Carbon\CarbonImmutable;
-use ReflectionClass;
+use Spatie\Attributes\Attributes;
 use Spatie\EventSourcing\Attributes\EventVersion;
 use Spatie\EventSourcing\Enums\MetaData;
 
@@ -15,13 +15,13 @@ abstract class ShouldBeStored
 
     public function eventVersion(): int
     {
-        $versionAttribute = (new ReflectionClass($this))->getAttributes(EventVersion::class)[0] ?? null;
+        $versionAttribute = Attributes::get($this, EventVersion::class);
 
         if (! $versionAttribute) {
             return 1;
         }
 
-        return $versionAttribute->newInstance()->version;
+        return $versionAttribute->version;
     }
 
     public function createdAt(): ?CarbonImmutable


### PR DESCRIPTION
## Summary

- Add `spatie/php-attribute-reader` as a dependency and use its `Attributes` API instead of manual `ReflectionClass` + `getAttributes()` + `newInstance()` calls
- Simplifies attribute reading in `ShouldBeStored`, `StoredEvent`, `EloquentStoredEventRepository`, and `CommandHandler`
- Removes unused `ReflectionClass`, `ReflectionException`, and `InvalidStoredEvent` imports where no longer needed