### PR TITLE
Change return type self to static on return $this

### DIFF
--- a/src/AggregateRoots/FakeAggregateRoot.php
+++ b/src/AggregateRoots/FakeAggregateRoot.php
@@ -29,7 +29,7 @@ class FakeAggregateRoot
      *
      * @return $this
      */
-    public function given($events): self
+    public function given($events): static
     {
         $events = Arr::wrap($events);
 
@@ -42,14 +42,14 @@ class FakeAggregateRoot
         return $this;
     }
 
-    public function when($callable): self
+    public function when($callable): static
     {
         $this->whenResult = $callable($this->aggregateRoot);
 
         return $this;
     }
 
-    public function then(callable $callback): self
+    public function then(callable $callback): static
     {
         $result = $callback($this->whenResult);
 
@@ -60,7 +60,7 @@ class FakeAggregateRoot
         return $this;
     }
 
-    public function assertNothingRecorded(): self
+    public function assertNothingRecorded(): static
     {
         Assert::assertCount(0, $this->getRecordedEventsAfterGiven());
 
@@ -72,7 +72,7 @@ class FakeAggregateRoot
      *
      * @return $this
      */
-    public function assertRecorded($expectedEvents): self
+    public function assertRecorded($expectedEvents): static
     {
         $recordedEvents = $this->getRecordedEventsWithoutUuid();
 
@@ -89,7 +89,7 @@ class FakeAggregateRoot
         return $this;
     }
 
-    public function assertNotRecorded($unexpectedEventClasses): self
+    public function assertNotRecorded($unexpectedEventClasses): static
     {
         $actualEventClasses = array_map(fn (ShouldBeStored $event) => get_class($event), $this->getRecordedEventsAfterGiven());
 
@@ -102,7 +102,7 @@ class FakeAggregateRoot
         return $this;
     }
 
-    public function assertEventRecorded(ShouldBeStored $expectedEvent): self
+    public function assertEventRecorded(ShouldBeStored $expectedEvent): static
     {
         $recordedEvents = $this->getRecordedEventsWithoutUuid();
 
@@ -111,7 +111,7 @@ class FakeAggregateRoot
         return $this;
     }
 
-    public function assertNothingApplied(): self
+    public function assertNothingApplied(): static
     {
         Assert::assertCount(0, $this->aggregateRoot->getAppliedEvents());
 
@@ -123,7 +123,7 @@ class FakeAggregateRoot
      *
      * @return $this
      */
-    public function assertApplied($expectedEvents): self
+    public function assertApplied($expectedEvents): static
     {
         $expectedEvents = Arr::wrap($expectedEvents);
 
@@ -155,7 +155,7 @@ class FakeAggregateRoot
         }
     }
 
-    public function __call($name, $arguments): self
+    public function __call($name, $arguments): static
     {
         $this->aggregateRoot->$name(...$arguments);
 

--- a/src/Projectionist.php
+++ b/src/Projectionist.php
@@ -68,7 +68,7 @@ class Projectionist
             ->addEventHandler($fakeHandlerClass);
     }
 
-    public function addProjector(string | Projector $projector): Projectionist
+    public function addProjector(string | Projector $projector): static
     {
         if ($projector instanceof Projector) {
             $this->projectors->addEventHandler($projector);
@@ -85,7 +85,7 @@ class Projectionist
         return $this;
     }
 
-    public function removeProjector(string $projectorClass): Projectionist
+    public function removeProjector(string $projectorClass): static
     {
         unset($this->pendingProjectors[$projectorClass]);
         $this->projectors->remove([$projectorClass]);
@@ -100,7 +100,7 @@ class Projectionist
         return $this->projectors->merge($this->reactors);
     }
 
-    public function withoutEventHandlers(?array $eventHandlers = null): Projectionist
+    public function withoutEventHandlers(?array $eventHandlers = null): static
     {
         if (is_null($eventHandlers)) {
             $this->pendingProjectors = [];
@@ -125,12 +125,12 @@ class Projectionist
         return $this;
     }
 
-    public function withoutEventHandler(string $eventHandler): Projectionist
+    public function withoutEventHandler(string $eventHandler): static
     {
         return $this->withoutEventHandlers([$eventHandler]);
     }
 
-    public function addProjectors(array $projectors): Projectionist
+    public function addProjectors(array $projectors): static
     {
         foreach ($projectors as $projector) {
             $this->addProjector($projector);
@@ -162,7 +162,7 @@ class Projectionist
             ->asyncEventHandlers($storedEvent);
     }
 
-    public function addReactor(string|EventHandler $reactor): Projectionist
+    public function addReactor(string|EventHandler $reactor): static
     {
         if ($reactor instanceof EventHandler) {
             $this->reactors->addEventHandler($reactor);
@@ -179,7 +179,7 @@ class Projectionist
         return $this;
     }
 
-    public function addReactors(array $reactors): Projectionist
+    public function addReactors(array $reactors): static
     {
         foreach ($reactors as $reactor) {
             $this->addReactor($reactor);
@@ -188,7 +188,7 @@ class Projectionist
         return $this;
     }
 
-    public function removeReactor(string $reactorClass): Projectionist
+    public function removeReactor(string $reactorClass): static
     {
         unset($this->pendingReactors[$reactorClass]);
         $this->reactors->remove([$reactorClass]);
@@ -231,7 +231,7 @@ class Projectionist
         throw InvalidEventHandler::notAnEventHandlingClassName($eventHandlerClass);
     }
 
-    public function removeEventHandler(string $eventHandlerClass): self
+    public function removeEventHandler(string $eventHandlerClass): static
     {
         if (is_subclass_of($eventHandlerClass, Projector::class)) {
             $this->removeProjector($eventHandlerClass);
@@ -248,7 +248,7 @@ class Projectionist
         throw InvalidEventHandler::notAnEventHandlingClassName($eventHandlerClass);
     }
 
-    public function addEventHandlers(array $eventHandlers): self
+    public function addEventHandlers(array $eventHandlers): static
     {
         foreach ($eventHandlers as $eventHandler) {
             $this->addEventHandler($eventHandler);

--- a/src/StoredEvents/Models/EloquentStoredEvent.php
+++ b/src/StoredEvents/Models/EloquentStoredEvent.php
@@ -41,7 +41,7 @@ class EloquentStoredEvent extends Model
         ], $this->getOriginalEvent());
     }
 
-    public function setOriginalEvent(ShouldBeStored $event): self
+    public function setOriginalEvent(ShouldBeStored $event): static
     {
         $this->originalEvent = $event;
 

--- a/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
+++ b/src/StoredEvents/Models/EloquentStoredEventQueryBuilder.php
@@ -14,28 +14,28 @@ use Spatie\EventSourcing\StoredEvents\StoredEvent;
  */
 class EloquentStoredEventQueryBuilder extends Builder
 {
-    public function startingFrom(int $storedEventId): self
+    public function startingFrom(int $storedEventId): static
     {
         $this->where('id', '>=', $storedEventId);
 
         return $this;
     }
 
-    public function afterVersion(int $version): self
+    public function afterVersion(int $version): static
     {
         $this->where('aggregate_version', '>', $version);
 
         return $this;
     }
 
-    public function whereAggregateRoot(string $uuid): self
+    public function whereAggregateRoot(string $uuid): static
     {
         $this->where('aggregate_uuid', $uuid);
 
         return $this;
     }
 
-    public function whereEvent(string ...$eventClasses): self
+    public function whereEvent(string ...$eventClasses): static
     {
         $this->whereIn('event_class', array_map(
             fn (string $eventClass): string => StoredEvent::getEventClass($eventClass),
@@ -45,14 +45,14 @@ class EloquentStoredEventQueryBuilder extends Builder
         return $this;
     }
 
-    public function wherePropertyIs(string $property, mixed $value): self
+    public function wherePropertyIs(string $property, mixed $value): static
     {
         $this->whereJsonContains(column: "event_properties->{$property}", value: $value);
 
         return $this;
     }
 
-    public function wherePropertyIsNot(string $property, mixed $value): self
+    public function wherePropertyIsNot(string $property, mixed $value): static
     {
         $this->whereJsonDoesntContain(column: "event_properties->{$property}", value: $value);
 

--- a/src/StoredEvents/ShouldBeStored.php
+++ b/src/StoredEvents/ShouldBeStored.php
@@ -29,7 +29,7 @@ abstract class ShouldBeStored
         return CarbonImmutable::make($this->metaData[MetaData::CREATED_AT] ?? null);
     }
 
-    public function setCreatedAt(CarbonImmutable $createdAt): self
+    public function setCreatedAt(CarbonImmutable $createdAt): static
     {
         $this->metaData[MetaData::CREATED_AT] = $createdAt;
 
@@ -41,7 +41,7 @@ abstract class ShouldBeStored
         return $this->metaData[MetaData::AGGREGATE_ROOT_UUID] ?? null;
     }
 
-    public function setAggregateRootUuid(string $uuid): self
+    public function setAggregateRootUuid(string $uuid): static
     {
         $this->metaData[MetaData::AGGREGATE_ROOT_UUID] = $uuid;
 
@@ -53,7 +53,7 @@ abstract class ShouldBeStored
         return $this->metaData[MetaData::STORED_EVENT_ID] ?? null;
     }
 
-    public function setStoredEventId(int|string $id): self
+    public function setStoredEventId(int|string $id): static
     {
         $this->metaData[MetaData::STORED_EVENT_ID] = $id;
 
@@ -65,7 +65,7 @@ abstract class ShouldBeStored
         return $this->metaData[MetaData::AGGREGATE_ROOT_VERSION] ?? null;
     }
 
-    public function setAggregateRootVersion(int $version): self
+    public function setAggregateRootVersion(int $version): static
     {
         $this->metaData[MetaData::AGGREGATE_ROOT_VERSION] = $version;
 
@@ -77,7 +77,7 @@ abstract class ShouldBeStored
         return $this->metaData;
     }
 
-    public function setMetaData(array $metaData): self
+    public function setMetaData(array $metaData): static
     {
         $this->metaData = $metaData;
 

--- a/src/Support/DiscoverEventHandlers.php
+++ b/src/Support/DiscoverEventHandlers.php
@@ -25,28 +25,28 @@ class DiscoverEventHandlers
         $this->basePath = app()->path();
     }
 
-    public function within(array $directories): self
+    public function within(array $directories): static
     {
         $this->directories = $directories;
 
         return $this;
     }
 
-    public function useBasePath(string $basePath): self
+    public function useBasePath(string $basePath): static
     {
         $this->basePath = $basePath;
 
         return $this;
     }
 
-    public function useRootNamespace(string $rootNamespace): self
+    public function useRootNamespace(string $rootNamespace): static
     {
         $this->rootNamespace = $rootNamespace;
 
         return $this;
     }
 
-    public function ignoringFiles(array $ignoredFiles): self
+    public function ignoringFiles(array $ignoredFiles): static
     {
         $this->ignoredFiles = $ignoredFiles;
 


### PR DESCRIPTION
Hi!

I came across this IDE warning when I created my event like this in the test files:
```php
$event = new ContractPriceSetEvent(
    rentalPrice: 1_000,
    vatCodeId: $this->vatCode->id,
    servicePrice: 100,
)->setAggregateRootUuid($this->contractId);

$event->rentalPrice;
//      ^ rentalPrice does not exist on ShouldBeStored
```
When returning `$this`, it should be of `static` type instead of `self`. After this fix, this warning disappears.

I initially changed it only on the `ShouldBeStored` class, but changed it to all classes since none of these are final. :)