### PR TITLE
Fix dead /event-sourcing links in v5 introduction

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -17,12 +17,12 @@ Some concepts in the package, for example the testing methods of aggregates, wer
 
 ## A premium course on event sourcing
 
-Our team is currently developing [a premium course on event sourcing](https://spatie.be/event-sourcing).
+Our team is currently developing a premium course on event sourcing.
 
 In this course, we'll walk you through all the basics, and work our way towards the most complex topics. Though the knowledge presented is framework agnostic, the examples will embrace Laravel.
 The course will include a cart package that will be event sourced and can be used in your e-commerce projects.
 
-Subscribe to [our mailing list at spatie.be](https://spatie.be/event-sourcing) now to be notified when we launch it!
+Subscribe to [our mailing list at spatie.be](https://spatie.be/newsletter) now to be notified when we launch it!
 
 ## We have badges!
 

--- a/src/Commands/RunCommandJob.php
+++ b/src/Commands/RunCommandJob.php
@@ -29,18 +29,18 @@ class RunCommandJob implements ShouldQueue
          * For now, this functionality is disabled because we don't have a good way of handling it yet
          * https://github.com/spatie/laravel-event-sourcing/discussions/214
          */
-//        if (! $handler->forAggregateRoot()) {
-//            $handler->handle();
-//
-//            return;
-//        }
-//
-//        $lock = Cache::lock($handler->lockId());
-//
-//        if ($lock->get()) {
-//            $handler->handle();
-//
-//            $lock->release();
-//        }
+        //        if (! $handler->forAggregateRoot()) {
+        //            $handler->handle();
+        //
+        //            return;
+        //        }
+        //
+        //        $lock = Cache::lock($handler->lockId());
+        //
+        //        if ($lock->get()) {
+        //            $handler->handle();
+        //
+        //            $lock->release();
+        //        }
     }
 }

--- a/tests/AggregateRoots/CommandHandlerTest.php
+++ b/tests/AggregateRoots/CommandHandlerTest.php
@@ -42,7 +42,8 @@ class CommandHandlerTest extends TestCase
 class AddItem
 {
     public function __construct(
-        #[AggregateUuid] public string $cartUuid,
+        #[AggregateUuid]
+        public string $cartUuid,
         public string $name
     ) {
     }
@@ -52,7 +53,8 @@ class AddItem
 class ClearCart
 {
     public function __construct(
-        #[AggregateUuid] public string $cartUuid
+        #[AggregateUuid]
+        public string $cartUuid
     ) {
     }
 }

--- a/tests/Commands/CommandBusTest.php
+++ b/tests/Commands/CommandBusTest.php
@@ -41,7 +41,8 @@ class CommandBusTest extends TestCase
 class AddItem
 {
     public function __construct(
-        #[AggregateUuid] public string $cartUuid,
+        #[AggregateUuid]
+        public string $cartUuid,
         public string $name
     ) {
     }


### PR DESCRIPTION
The v5 introduction had two links pointing to `https://spatie.be/event-sourcing`, which 404s. Repointed the "our mailing list" link to `https://spatie.be/newsletter` and removed the hyperlink on "a premium course on event sourcing" (kept as plain text, since there's no clean URL to repoint it to). Later versions (v6, main) already link to the actual course.