### PR TITLE
Fix “Reactors” and “Sagas” chapter numbers

### DIFF
--- a/docs/using-reactors/writing-your-first-reactor.md
+++ b/docs/using-reactors/writing-your-first-reactor.md
@@ -65,5 +65,5 @@ no mail will be sent.
 
 Reactors and process managers (which are built on top of the core reactor principle) are thoroughly discussed in [Event Sourcing in Laravel](https://event-sourcing-laravel.com/). More specifically, you want to read these chapters:
 
-- 08. Reactors
-- 15. Sagas
+- 10\. Reactors
+- 17\. Sagas


### PR DESCRIPTION
Also, the dots are escaped as the list isn’t properly displayed on your docs: https://spatie.be/docs/laravel-event-sourcing/v7/using-reactors/writing-your-first-reactor