### PR TITLE
Allow phpdocumentor/reflection-docblock 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
         "illuminate/database": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/events": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
-        "phpdocumentor/reflection-docblock": "^5.6.1",
+        "phpdocumentor/reflection-docblock": "^5.6.1|^6.0",
         "spatie/better-types": "^1.0",
         "spatie/laravel-package-tools": "^1.19",
         "spatie/php-attribute-reader": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
         "pestphp/pest": "^2.34|^3.7.4|^4.0",
         "phpunit/phpunit": "^9.5.10|^10.5|^11.5.3|^12.5.12",
         "spatie/fork": "^1.2.4",
-        "spatie/pest-plugin-snapshots": "^1.1|^2.2",
-        "spatie/phpunit-snapshot-assertions": "^4.0|^5.1.8 <5.2"
+        "spatie/pest-plugin-snapshots": "^1.1|^2.3.1",
+        "spatie/phpunit-snapshot-assertions": "^4.0|^5.3.1"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Fixes #534.

Symfony 8 declares `conflict: phpdocumentor/reflection-docblock <5.2|>=7`, so a Laravel 13 app resolves reflection-docblock to 6.0.3. Our `^5.6.1` cap made the package uninstallable there. Widened to `^5.6.1|^6.0`.

(The issue suggests widening to `^7.0`. That won't work: 7.x doesn't exist, and Symfony 8 conflicts with `>=7` anyway.)

The second commit lifts the `spatie/phpunit-snapshot-assertions <5.2` cap. That cap held `symfony/property-access` at `^7`, which meant the Laravel 13 CI job was never actually testing against Symfony 8. `pest-plugin-snapshots` 2.3+ requires snapshot-assertions `^5.3`, which is where the `SnapshotIdAware` incompatibility behind the cap got resolved. Every matrix row now installs `symfony/serializer` v8.1.4 and reflection-docblock 6.0.3.

Verified a fresh Laravel 13.24.0 + Symfony 8.1.4 app: `composer require spatie/laravel-event-sourcing:7.15.0` fails, this branch installs, and a `@param Money[]` docblock-typed property round-trips correctly through the serializer (the `PhpDocExtractor` path is the only reason this dependency exists).